### PR TITLE
Add upload flow

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,8 @@ RUN apt-get update && apt-get install -y \
     curl \
     wget \
     vim \
-    software-properties-common
+    software-properties-common \
+    postgresql-client
 
 RUN pip install pipenv
 

--- a/README.md
+++ b/README.md
@@ -13,12 +13,11 @@ Standard django stuff:
 python manage.py makemigrations
 python manage.py migrate
 python manage.py runserver 0.0.0.0:8000
-http://localhost:8000/ppe
 ```
+Then http://localhost:8000
 
 ## Import Data
 1. Create a directory called `private-data` at the repo root (automatically gitignored)
-2. Insert the PPE spreadsheet at `ppe_orders.xlsx`
-3. Insert the suppliers spreadsheet at `ppe_make.xlsx`
-3. `cd nyc_data`
+2. Copy in all your spreadsheets. Names don't matter!
+2. `docker-compose exec backend bash`
 3. `python manage.py runscript ppe_import`

--- a/nyc_data/ppe/data_import.py
+++ b/nyc_data/ppe/data_import.py
@@ -9,7 +9,7 @@ from ppe import data_mappings
 from ppe.models import Purchase, Delivery, Inventory, ImportStatus, DataImport
 from xlsx_utils import import_xlsx
 
-mappings = {
+MAPPINGS = {
     DataSource.EDC_MAKE: data_mappings.SUPPLIERS_AND_PARTNERS,
     DataSource.INVENTORY: data_mappings.INVENTORY,
     DataSource.EDC_PPE: data_mappings.DCAS_DAILY_SOURCING
@@ -39,8 +39,8 @@ def import_data(path: Path, data_source: DataSource, uploaded_by: Optional[str] 
 
     uploaded_by = uploaded_by or ''
 
-    mapping = mappings[data_source]
-    data = import_xlsx(path, mapping.sheet_name, mapping)
+    mapping = MAPPINGS[data_source]
+    data = import_xlsx(path, mapping)
     data = list(data)
     obj_types = {Purchase, Delivery, Inventory}
     num_active_objects = {

--- a/nyc_data/ppe/data_import.py
+++ b/nyc_data/ppe/data_import.py
@@ -1,9 +1,11 @@
 import collections
 import dataclasses as dc
 import hashlib
+import tempfile
 from pathlib import Path
 from typing import Optional
 
+import xlsx_utils
 from ppe.data_mappings import DataSource
 from ppe import data_mappings
 from ppe.models import Purchase, Delivery, Inventory, ImportStatus, DataImport
@@ -20,8 +22,40 @@ class DataImportError(Exception):
     pass
 
 
+def handle_upload(f) -> DataImport:
+    with tempfile.NamedTemporaryFile('w+b', delete=False, suffix=f.name) as upload_target:
+        for chunk in f.chunks():
+            upload_target.write(chunk)
+        return smart_import(Path(upload_target.name))
+
+
 def import_in_progress(data_source: DataSource):
     return DataImport.objects.filter(data_source=data_source, status=ImportStatus.candidate)
+
+
+class NoMappingForFileError(DataImportError):
+    pass
+
+
+class MultipleMappingsForFileError(DataImportError):
+    pass
+
+
+class ImportInProgressError(DataImportError):
+    def __init__(self, import_id):
+        self.import_id = import_id
+
+
+def smart_import(path: Path) -> DataImport:
+    possible_mappings = xlsx_utils.guess_mapping(path, list(MAPPINGS.values()))
+    if len(possible_mappings) == 0:
+        raise NoMappingForFileError()
+    elif len(possible_mappings) > 1:
+        raise MultipleMappingsForFileError()
+    else:
+        inferred_mapping = possible_mappings[0]
+        data_source = [src for (src, mapping) in MAPPINGS.items() if mapping == inferred_mapping][0]
+        return import_data(path, data_source)
 
 
 def import_data(path: Path, data_source: DataSource, uploaded_by: Optional[str] = None, overwrite_in_prog=False):
@@ -31,8 +65,7 @@ def import_data(path: Path, data_source: DataSource, uploaded_by: Optional[str] 
         if overwrite_in_prog:
             in_progress.update(status=ImportStatus.replaced)
         else:
-            raise DataImportError(
-                f"Can't import data -- there is already an import in progress ({in_progress.first().import_date})")
+            raise ImportInProgressError(in_progress.first().id)
 
     with open(path, 'rb') as f:
         checksum = hashlib.sha256(f.read())

--- a/nyc_data/ppe/forms.py
+++ b/nyc_data/ppe/forms.py
@@ -1,0 +1,7 @@
+from django import forms
+
+class UploadFileForm(forms.Form):
+    file = forms.FileField()
+    name = forms.CharField(label='Your name')
+    notes = forms.Textarea()
+

--- a/nyc_data/ppe/models.py
+++ b/nyc_data/ppe/models.py
@@ -59,12 +59,17 @@ class DataImport(models.Model):
             raise Exception('Can only compute a delta on a candidate import')
 
         active_import = DataImport.objects.filter(status=ImportStatus.active, data_source=self.data_source).first()
+
         if active_import:
             active_objects = active_import.imported_objects()
         else:
             active_objects = {}
 
-        new_objects = {k: set(objs).difference(active_objects.get(k)) for k, objs in self.imported_objects().items()}
+        new_objects = {
+            k: set(objs).difference(active_objects.get(k)) if k in active_objects.keys() else set(objs) \
+                for k, objs in self.imported_objects().items() 
+        }
+
         return UploadDelta(
             previous=active_import,
             active_stats={tpe.__name__: len(objs) for (tpe, objs) in active_objects.items()},

--- a/nyc_data/ppe/models.py
+++ b/nyc_data/ppe/models.py
@@ -1,5 +1,6 @@
 import uuid
 from enum import Enum
+from typing import NamedTuple, Dict
 
 from django.contrib.postgres.fields import JSONField
 from django.db import models
@@ -22,6 +23,7 @@ class ImportStatus(str, Enum):
     active = "active"
     replaced = "replaced"
     candidate = "candidate"
+    cancelled = "cancelled"
 
 
 class DataImport(models.Model):
@@ -32,20 +34,55 @@ class DataImport(models.Model):
     uploaded_by = models.TextField(blank=True)
     file_checksum = models.TextField()
     file_name = models.TextField()
+    file = models.FileField
 
     @classmethod
     def sanity(cls):
         # for each data_source, at most 1 active
-        for _, src in DataSource.__members__.item():
+        for _, src in DataSource.__members__.items():
             ct = DataImport.objects.filter(data_source=src, status=ImportStatus.active).count()
             if ct > 1:
                 print(f'Something is weird, more than one active object for {src}')
                 return False
         return True
 
+    def cancel(self):
+        self.status = ImportStatus.cancelled
+
     def display(self):
         return f'File uploaded {self.import_date.strftime("%d/%m/%y")} by {self.uploaded_by or "unknown"}. Filename: {self.file_name}'
 
+    def compute_delta(self):
+        if not self.sanity():
+            raise Exception("Can't compute a delta. Something is horribly wrong in the DB")
+        if self.status != ImportStatus.candidate:
+            raise Exception('Can only compute a delta on a candidate import')
+
+        active_import = DataImport.objects.filter(status=ImportStatus.active, data_source=self.data_source).first()
+        if active_import:
+            active_objects = active_import.imported_objects()
+        else:
+            active_objects = {}
+
+        new_objects = {k: set(objs).difference(active_objects.get(k)) for k, objs in self.imported_objects().items()}
+        return UploadDelta(
+            previous=active_import,
+            active_stats={tpe.__name__: len(objs) for (tpe, objs) in active_objects.items()},
+            candidate_stats={tpe.__name__: len(objs) for (tpe, objs) in active_objects.items()},
+            new_objects=new_objects
+
+        )
+
+    def imported_objects(self):
+        return {tpe: tpe.objects.prefetch_related('source').filter(source=self) for tpe in
+                [Delivery, Inventory, Purchase]}
+
+class UploadDelta(NamedTuple):
+    previous: DataImport
+    active_stats: Dict[str, int]
+    candidate_stats: Dict[str, int]
+
+    new_objects: Dict[str, any]
 
 class BaseModel(models.Model):
     id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)

--- a/nyc_data/ppe/templates/upload.html
+++ b/nyc_data/ppe/templates/upload.html
@@ -1,0 +1,27 @@
+{% extends "base.html" %}
+
+{% block titlebar %}
+<h2>Upload data to the dashboard</h2>
+{% endblock %}
+
+{% block content %}
+<div class="upload">
+    <h2>Upload a new spreadsheet</h2>
+    {% if error != None %}
+    Error! {{ error }}
+    {% endif %}
+
+    {% if import_in_progress %}
+    <form enctype="multipart/form-data" method="post" action="/cancel/{{ import_in_progress }}/">
+        {% csrf_token %}
+        <input type="submit" value="Cancel current import in progress">
+    </form>
+
+    {% endif %}
+    <form enctype="multipart/form-data" method="post" action="/upload/">
+        {% csrf_token %}
+        {{ form }}
+        <input type="submit" value="Submit">
+    </form>
+</div>
+{% endblock %}

--- a/nyc_data/ppe/templates/verify_upload.html
+++ b/nyc_data/ppe/templates/verify_upload.html
@@ -1,0 +1,22 @@
+{% extends "base.html" %}
+
+{% block titlebar %}
+<h2>Confirm your upload</h2>
+{% endblock %}
+
+{% block content %}
+<div class="upload">
+    <h2>Verify your upload</h2>
+    Your upload replaces an upload made by {{ delta.previous.uploaded_by | default:"Unknown user" }} on {{ delta.previous.import_date }}
+    <br />
+
+    They uploaded: {{ delta.active_stats }}<br />
+    You uploaded: {{ delta.candidate_stats }}<br />
+
+    You added these new objects: {{ delta.new_objects }}
+    <form method="post" action="/verify/{{ import_id }}/">
+        {% csrf_token %}
+        <input type="submit" value="Confirm Upload">
+    </form>
+</div>
+{% endblock %}

--- a/nyc_data/ppe/urls.py
+++ b/nyc_data/ppe/urls.py
@@ -4,5 +4,8 @@ from ppe import views
 
 urlpatterns = [
     path("", views.default, name="index"),
-    path("drilldown", views.drilldown, name="drilldown")
+    path("drilldown", views.drilldown, name="drilldown"),
+    path("upload/", views.Upload.as_view(), name="upload"),
+    path("verify/<str:import_id>/", views.Verify.as_view(), name="verify"),
+    path("cancel/<str:import_id>/", views.CancelImport.as_view(), name="cancel")
 ]

--- a/nyc_data/ppe/views.py
+++ b/nyc_data/ppe/views.py
@@ -1,16 +1,17 @@
-# Create your views here.
-
 from datetime import datetime, timedelta
+from typing import NamedTuple, Optional
 
-from django.http import HttpResponse
+from django.forms import Form
+from django.http import HttpResponse, HttpResponseRedirect
 from django.shortcuts import render
+from django.urls import reverse
+from django.views import View
 from django_tables2 import RequestConfig
 
-from ppe import aggregations, dataclasses as dc
+from ppe import aggregations, dataclasses as dc, forms, data_import
 from ppe.drilldown import deliveries_for_item
+from ppe.models import DataImport
 
-
-# Create your views here.
 
 def mayoral_rollup(row):
     return row.to_mayoral_category()
@@ -49,3 +50,43 @@ def drilldown(request):
         "deliveries": [d.to_dataclass() for d in deliveries_for_item(category, rollup)]
     }
     return render(request, "drilldown.html", context)
+
+
+class UploadContext(NamedTuple):
+    form: Form = forms.UploadFileForm
+    error: Optional[str] = None
+    import_in_progress: Optional[str] = None
+
+
+class Upload(View):
+    def get(self, request):
+        return render(request, "upload.html", UploadContext()._asdict())
+
+    def post(self, request):
+        form = forms.UploadFileForm(request.POST, request.FILES)
+        if form.is_valid():
+            try:
+                import_obj = data_import.handle_upload(request.FILES['file'])
+                return HttpResponseRedirect(reverse('verify', kwargs={"import_id": import_obj.id}))
+            except data_import.ImportInProgressError as ex:
+                return render(request, "upload.html",
+                              UploadContext(error="Import already in progress for this file type",
+                                            import_in_progress=ex.import_id)._asdict())
+
+
+class Verify(View):
+    def get(self, request, import_id):
+        import_obj = DataImport.objects.get(id=import_id)
+        return render(request, "verify_upload.html", dict(import_id=import_id, delta=import_obj.compute_delta()))
+
+    def post(self, request, import_id):
+        data_import.complete_import(DataImport.objects.get(id=import_id))
+        return HttpResponseRedirect(reverse('index'))
+
+class CancelImport(View):
+    def post(self, request, import_id):
+        import_obj = DataImport.objects.get(id=import_id)
+        import_obj.cancel()
+        import_obj.save()
+        return HttpResponseRedirect(reverse('upload'))
+


### PR DESCRIPTION
Uploads go through 2 phases: `candidate` and `active`. This allows us to ingest data, compare it to the existing data, then allow the user to confirm that it seems sensible before proceeding.

Since we can infer the contents of the files, we don't need to ask the user what they're uploading.

Upload page:
<img width="713" alt="Screenshot 2020-04-11 16 04 33" src="https://user-images.githubusercontent.com/492903/79053830-46f3f180-7c0e-11ea-8195-0eb35e26b87c.png">


Verify page:
<img width="1201" alt="Screenshot 2020-04-11 16 05 02" src="https://user-images.githubusercontent.com/492903/79053829-465b5b00-7c0e-11ea-8e32-d93ce86ead3d.png">
