### PR TITLE
Refactor CSS on rollup buttons so that the entire button is clickable

### DIFF
--- a/nyc_data/ppe/static/style.css
+++ b/nyc_data/ppe/static/style.css
@@ -40,7 +40,18 @@ section.container {
     font-size: 42px;
     line-height: 49px;
 
+    justify-content: space-between;
+
     color: #666666;
+}
+
+.upload-btn {
+    border-radius: 20px;
+    background: #EEEEEE;
+    font-size: 14px;
+    text-decoration: none;
+    color: rgb(102, 102, 102);
+    padding: 20px;
 }
 
 .title-bar {
@@ -233,18 +244,19 @@ td:last-child {
     list-style-type: none;
 }
 .toggle li {
-    border: 1px solid #ddd;
-    padding: 10px 20px;
-    border-radius: 20px;
     font-weight: 300;
     margin-right: 10px;
 }
-.toggle li.active {
+
+.toggle li.active a {
     background: #666;
 }
 .toggle a {
     color: #666;
+    border-radius: 20px;
     text-decoration: none;
+    padding: 10px 20px;
+    border: 1px solid #ddd;
 }
 .toggle li.active a {
     color: #fff;

--- a/nyc_data/ppe/templates/base.html
+++ b/nyc_data/ppe/templates/base.html
@@ -9,7 +9,12 @@
         <strong>CONFIDENTIAL.</strong>&nbsp;DO NOT DISTRIBUTE WITHOUT AUTHORIZATION.
     </section>
     <section class="brand-bar container">
+        <div>
         NYC<b>PPE</b>
+        </div>
+        <div>
+        <a class="upload-btn" href="/upload">Upload new data</a>
+        </div>
     </section>
     <section class="title-bar">
         <section class="container">


### PR DESCRIPTION
Add an upload button and refactor the CSS on the rollup buttons to make the whole button clickable instead of just the link.

<img width="1360" alt="Screenshot 2020-04-11 16 32 14" src="https://user-images.githubusercontent.com/492903/79054375-42313c80-7c12-11ea-9f00-4522ed26484d.png">
