### PR TITLE
Make the balance bars accurate & show the item name in drilldown

### DIFF
--- a/nyc_data/ppe/aggregations.py
+++ b/nyc_data/ppe/aggregations.py
@@ -164,8 +164,8 @@ class AggregationTable(tables.Table):
 
             unit=unit,
             percent_str=percent_str,
-            neg_width=min(min(int(percent * 100), 0) * -1, 50),
-            pos_width=max(min(int(percent * 100), 50), 0),
+            neg_width=min(min(int(percent * 50), 0) * -1, 50),
+            pos_width=max(min(int(percent * 50), 50), 0),
             neg_delta=50 - min(min(int(percent * 100), 0) * -1, 50),
             pos_delta=50 - max(min(int(percent * 100), 50), 0),
         )

--- a/nyc_data/ppe/templates/drilldown.html
+++ b/nyc_data/ppe/templates/drilldown.html
@@ -14,7 +14,7 @@
             <dt>{{day.grouper}}</dt>
 
             {% for delivery in day.list %}
-                <dd class="tooltip" aria-label="{{delivery.vendor}}">Receiving <span class="quantity">{{ delivery.quantity|pretty_num }}</span> – {{ delivery.description|default:"No description" }}</dd>
+                <dd class="tooltip" aria-label="{{delivery.vendor}}">Receiving <span class="quantity">{{ delivery.quantity|pretty_num }}</span> {{ delivery.item }} – {{ delivery.description|default:"No description" }}</dd>
             {% endfor %}
         {% if forloop.last %}</dl>{% endif %}
     {% endfor %}
@@ -25,7 +25,7 @@
         {% for purchase in purchases %}
         {% if purchase.unscheduled_quantity %}
         <li class="tooltip" aria-label="{{purchase.vendor}}">
-            Receiving {{purchase.unscheduled_quantity|pretty_num}} – {{purchase.description|default:"No description"}}
+            Receiving {{purchase.unscheduled_quantity|pretty_num}} {{ purchase.item }} – {{purchase.description|default:"No description"}}
         </li>
         {% endif %}
         {% endfor %}


### PR DESCRIPTION
if we're in mayoral categories (default), knowing the item name is actually useful.