### PR TITLE
Greg/drilldown viz

### DIFF
--- a/nyc_data/ppe/templates/drilldown.html
+++ b/nyc_data/ppe/templates/drilldown.html
@@ -28,7 +28,6 @@
         {% if forloop.last %}</dl>{% endif %}
     {% endfor %}
 
-    <br />
     <hr />
 
     <h2>Unscheduled Supply (Total: {{ unscheduled_total | pretty_num }})</h2>

--- a/nyc_data/ppe/templates/drilldown.html
+++ b/nyc_data/ppe/templates/drilldown.html
@@ -7,25 +7,37 @@
 
 {% block content %}
 <div class="incoming-supply">
-    <h2>Incoming Supply</h2>
+    <h2>Incoming Supply (Total Scheduled: {{scheduled_total|pretty_num}})</h2>
+    <p>Scheduled for delivery in:</p>
+    <ul>
+        <li><b>Past:</b> {{deliveries_past|pretty_num}}</li>
+        <li><b>Next 3 days:</b> {{deliveries_next_three|pretty_num}}</li>
+        <li><b>Next 7 days:</b> {{deliveries_next_week|pretty_num}}</li>
+        <li><b>Next 30 days:</b> {{deliveries_next_thirty|pretty_num}}</li>
+    </ul>
     {% regroup deliveries by delivery_date as date_list %}
     {% for day in date_list %}
-        {% if forloop.first %}<dl>{% endif %}
-            <dt>{{day.grouper}}</dt>
+    {% if forloop.first %}<dl>{% endif %}
+        <dt>{{day.grouper}}</dt>
 
-            {% for delivery in day.list %}
-                <dd class="tooltip" aria-label="{{delivery.vendor}}">Receiving <span class="quantity">{{ delivery.quantity|pretty_num }}</span> {{ delivery.item }} – {{ delivery.description|default:"No description" }}</dd>
-            {% endfor %}
+        {% for delivery in day.list %}
+        <dd class="tooltip" aria-label="{{delivery.vendor}}">Receiving <span
+                class="quantity">{{ delivery.quantity|pretty_num }}</span> {{ delivery.item }} –
+            {{ delivery.description|default:"No description" }}</dd>
+        {% endfor %}
         {% if forloop.last %}</dl>{% endif %}
     {% endfor %}
 
+    <br />
+    <hr />
 
-    <h2>Unscheduled Supply</h2>
+    <h2>Unscheduled Supply (Total: {{ unscheduled_total | pretty_num }})</h2>
     <ul>
         {% for purchase in purchases %}
         {% if purchase.unscheduled_quantity %}
         <li class="tooltip" aria-label="{{purchase.vendor}}">
-            Receiving {{purchase.unscheduled_quantity|pretty_num}} {{ purchase.item }} – {{purchase.description|default:"No description"}}
+            Receiving {{purchase.unscheduled_quantity|pretty_num}} {{ purchase.item }} –
+            {{purchase.description|default:"No description"}}
         </li>
         {% endif %}
         {% endfor %}

--- a/nyc_data/ppe/views.py
+++ b/nyc_data/ppe/views.py
@@ -51,12 +51,21 @@ def drilldown(request):
         rollup = lambda x: x
         cat_display = dc.Item(category).display()
     drilldown_res = drilldown_result(category, rollup)
+    purchases = drilldown_res[0]
+    deliveries = drilldown_res[1]
+    #deliveries_next_three = datetime.now() + timedelta(days=3)
 
     context = {
         "asset_category": cat_display,
         # conversion to data class handles conversion to display names, etc.
-        "purchases": [p.to_dataclass() for p in drilldown_res[0]],
-        "deliveries": [d.to_dataclass() for d in drilldown_res[1]],
+        "purchases": [p.to_dataclass() for p in purchases],
+        "deliveries": [d.to_dataclass() for d in deliveries],
+        "deliveries_past" : sum([d.quantity for d in deliveries if d.delivery_date <= datetime.now().date()]),
+        "deliveries_next_three" : sum([d.quantity for d in deliveries if datetime.now().date() <= d.delivery_date <= datetime.now().date() + timedelta(days=3)]),
+        "deliveries_next_week" : sum([d.quantity for d in deliveries if datetime.now().date() <= d.delivery_date <= datetime.now().date() + timedelta(days=7)]),
+        "deliveries_next_thirty" : sum([d.quantity for d in deliveries if datetime.now().date() <= d.delivery_date <= datetime.now().date() + timedelta(days=30)]),
+        "scheduled_total" : sum([d.quantity for d in deliveries]),
+        "unscheduled_total" : sum([purch.unscheduled_quantity for purch in purchases if purch.unscheduled_quantity])
     }
     return render(request, "drilldown.html", context)
 


### PR DESCRIPTION
Adds sums of scheduled deliveries of each item's drilldown by different time frames. 

Adds total scheduled / unscheduled in the header of both sections

Passed the variable values into the `context` dict which is passed into `drilldown.html`. There might be a better practice to do those calcs within the `drilldown.html` template, but am new to Django Template Language so did it this way