### PR TITLE
Add more info to the drilldown

### DIFF
--- a/nyc_data/ppe/data_mapping/mappers/README.md
+++ b/nyc_data/ppe/data_mapping/mappers/README.md
@@ -1,0 +1,44 @@
+## Data Ingestion Infrastructure
+The data that we ingest is grouped into "data files" -- the key concept here is that data from the same file
+replaces data uploaded by an earlier version of the file. Its been refactored a few times. I (Russell) will probably refactor it at least one more time to more cleanly support different file formats. The intention, however, is to provide an actual data import layer that is agnostic to the import file format (eg. write the same code to import an object that's an XLSX or a similarly formatted CSV). 
+
+### Concepts
+Each mapping contains a few pieces:
+```python
+class SheetMapping(NamedTuple):
+    data_file: DataFile
+    sheet_name: Optional[str]  # None for CSV
+    mappings: Set[Mapping]
+    include_raw: bool
+    obj_constructor: Optional[Callable[[Any], 'ImportedRow']] = None
+```
+
+Data is converted from CSVs and excel spreadsheets into a series of Python `dict`s. From there, the mappings load
+specified keys from these dicts into subclasses of `ImportedRow`. `ImportedRow` subclasses validate the data, and return any database rows that should be generated.
+
+This flow is driven by `xlsx_utils.import_xlsx`. For each row in the sheet, it will:
+1. Extract the keys defined by the mapping
+2. Call the provided object constructor to create a row object (defined by you)
+3. Call `to_objects()` on that row object.
+4. Save those objects to the database.
+
+
+### Format Inference
+There is some extremely basic code to guess what type of spreadsheet or CSV we're getting. It lives in `xlsx_utils.guess_mapping`
+
+
+### Mappers
+A mapper is the atom of mapping one cell in the spreadsheet to the structured data passed to your `ImportedRow` subclass.
+
+```python
+class Mapping(NamedTuple):
+    sheet_column_name: str
+    obj_column_name: str
+    proc: Optional[Callable[[str, ErrorCollector], Any]] = None
+```
+
+Of interest is the `proc` argument, an optional function to map a string to structured data. Many `proc` functions are provided
+in `data_mapping.utils`. These functions properly handle collating errors to eventually display in the UI if this is widely used.
+
+### Gotchas
+* We can't handle formulas in excel sheets. If the sheet has formulas, we'll need to convert it to a CSV instead.

--- a/nyc_data/ppe/data_mapping/mappers/inventory_from_facilities.py
+++ b/nyc_data/ppe/data_mapping/mappers/inventory_from_facilities.py
@@ -48,10 +48,6 @@ class InventoryRow(ImportedRow, NamedTuple):
                 quantity=self.gowns,
             ),
             Inventory(
-                item=Item.gown,
-                quantity=self.gowns,
-            ),
-            Inventory(
                 item=Item.ponchos,
                 quantity=self.ponchos,
             ),

--- a/nyc_data/ppe/drilldown.py
+++ b/nyc_data/ppe/drilldown.py
@@ -15,7 +15,7 @@ def drilldown_result(item_type: str, rollup_fn: Callable[[dc.Item], str]):
     purchases = Purchase.active().prefetch_related('deliveries').order_by('deliveries__delivery_date')
     purchases = [p for p in purchases if rollup_fn(dc.Item(p.item)) == item_type]
     deliveries = ScheduledDelivery.active().prefetch_related('purchase').order_by('delivery_date')
-    deliveries = [d for d in deliveries if rollup_fn(dc.Item(d.purchase.item)) == item_type]
+    deliveries = [d for d in deliveries if rollup_fn(dc.Item(d.item)) == item_type]
     inventory = [i for i in Inventory.active() if rollup_fn(dc.Item(i.item)) == item_type]
     return DrilldownResult(purchases, deliveries, inventory)
 

--- a/nyc_data/ppe/templates/drilldown.html
+++ b/nyc_data/ppe/templates/drilldown.html
@@ -8,19 +8,20 @@
 {% block content %}
 <div class="incoming-supply">
     <div>
-    <h2>Current Inventory</h2>
-    <ul>
-        {%for item in inventory %}
-        <li>{{item.item|display_name}}: {{item.quantity|pretty_num}}</li>
-        {% endfor %}
-    </ul>
-    <!--<h3>Disbursed to facilities (hospitals, nursing homes, etc.) last 7 days</h3>
-    <ul>
-        {%for item, ct in facility_deliveries.items%}
-        <li>{{item|display_name}}: {{ct|pretty_num}}</li>
-        {% endfor %}
-    </ul>-->
-    <hr/></div>
+        <h2>Current Inventory</h2>
+        <ul>
+            {%for item in inventory %}
+            <li>{{item.item|display_name}}: {{item.quantity|pretty_num}}</li>
+            {% endfor %}
+        </ul>
+        <h4>Disbursed to facilities (hospitals, nursing homes, etc.) last 7 days</h4>
+        <ul>
+            {%for item, ct in facility_deliveries.items%}
+            <li>{{item|display_name}}: {{ct|pretty_num}}</li>
+            {% endfor %}
+        </ul>
+        <hr/>
+    </div>
 
     <div class="drilldown-detail supply-scheduled">
         <h2>Incoming Supply</h2>

--- a/nyc_data/ppe/templates/drilldown.html
+++ b/nyc_data/ppe/templates/drilldown.html
@@ -28,12 +28,12 @@
         <div class="incoming-rollup">
             <p>Scheduled for delivery in:</p>
             <ul>
-                <li><b>Past</b> {{deliveries_past|pretty_num}}</li>
                 <li><b>Next 3 days</b> {{deliveries_next_three|pretty_num}}</li>
                 <li><b>Next 7 days</b> {{deliveries_next_week|pretty_num}}</li>
                 <li><b>Next 30 days</b> {{deliveries_next_thirty|pretty_num}}</li>
                 <li><b>Total Scheduled</b> {{scheduled_total|pretty_num}}</li>
                 <li><b>Total Unscheduled</b> {{unscheduled_total|pretty_num}}</li>
+                <li><b>Total Received (all time)</b> {{deliveries_past|pretty_num}}</li>
             </ul>
         </div>
         {% regroup deliveries by delivery_date as date_list %}

--- a/nyc_data/ppe/templates/drilldown.html
+++ b/nyc_data/ppe/templates/drilldown.html
@@ -7,13 +7,20 @@
 
 {% block content %}
 <div class="incoming-supply">
+    <div>
     <h2>Current Inventory</h2>
     <ul>
-    {%for item in inventory %}
+        {%for item in inventory %}
         <li>{{item.item|display_name}}: {{item.quantity|pretty_num}}</li>
-    {% endfor %}
+        {% endfor %}
     </ul>
-    <hr />
+    <!--<h3>Disbursed to facilities (hospitals, nursing homes, etc.) last 7 days</h3>
+    <ul>
+        {%for item, ct in facility_deliveries.items%}
+        <li>{{item|display_name}}: {{ct|pretty_num}}</li>
+        {% endfor %}
+    </ul>-->
+    <hr/></div>
 
     <div class="drilldown-detail supply-scheduled">
         <h2>Incoming Supply</h2>
@@ -26,21 +33,30 @@
                 <li><b>Next 30 days</b> {{deliveries_next_thirty|pretty_num}}</li>
                 <li><b>Total</b> {{scheduled_total|pretty_num}}</li>
                 <li><b>Unscheduled</b> {{unscheduled_total|pretty_num}}</li>
+                <li><b>Received</b> {{received_total|pretty_num}}</li>
             </ul>
         </div>
         {% regroup deliveries by delivery_date as date_list %}
         {% for day in date_list %}
-            {% if forloop.first %}<table class="drilldown-deliveries">{% endif %}
-                <tr><th rowspan="{{day.list|length}}">{{day.grouper}}</th>
-                    {% for delivery in day.list %}
-                        {% if not forloop.first %}<tr>{% endif %}
-                        <td class="drilldown-deliveries-quantity"><span class="quantity">{{ delivery.quantity|pretty_num }} {{ delivery.item }}</span></td>
-                        <td class="drilldown-deliveries-desc">{{ delivery.description|default:"No description" }}</td>
-                        <td class="drilldown-deliveries-vendor">{{delivery.vendor}}</td>
-                        {% if not forloop.last %}</tr>{% endif %}
-                    {% endfor %}
-                </tr>
-            {% if forloop.last %}</table>{% endif %}
+        {% if forloop.first %}
+        <table class="drilldown-deliveries">{% endif %}
+            <tr>
+                <th rowspan="{{day.list|length}}">{{day.grouper}}</th>
+                {% for delivery in day.list %}
+                {% if not forloop.first %}
+            <tr>{% endif %}
+                <td class="drilldown-deliveries-quantity"><span class="quantity">{{ delivery.quantity|pretty_num }} {{ delivery.item }}</span>
+                </td>
+                <td class="drilldown-deliveries-desc">{{ delivery.description|default:"No description" }}</td>
+                <td class="drilldown-deliveries-vendor">{{delivery.vendor}}</td>
+                {% if not forloop.last %}
+            </tr>
+            {% endif %}
+            {% endfor %}
+            </tr>
+            {% if forloop.last %}
+        </table>
+        {% endif %}
         {% endfor %}
     </div>
 

--- a/nyc_data/ppe/templates/drilldown.html
+++ b/nyc_data/ppe/templates/drilldown.html
@@ -32,9 +32,8 @@
                 <li><b>Next 3 days</b> {{deliveries_next_three|pretty_num}}</li>
                 <li><b>Next 7 days</b> {{deliveries_next_week|pretty_num}}</li>
                 <li><b>Next 30 days</b> {{deliveries_next_thirty|pretty_num}}</li>
-                <li><b>Total</b> {{scheduled_total|pretty_num}}</li>
-                <li><b>Unscheduled</b> {{unscheduled_total|pretty_num}}</li>
-                <li><b>Received</b> {{received_total|pretty_num}}</li>
+                <li><b>Total Scheduled</b> {{scheduled_total|pretty_num}}</li>
+                <li><b>Total Unscheduled</b> {{unscheduled_total|pretty_num}}</li>
             </ul>
         </div>
         {% regroup deliveries by delivery_date as date_list %}
@@ -46,7 +45,7 @@
                 {% for delivery in day.list %}
                 {% if not forloop.first %}
             <tr>{% endif %}
-                <td class="drilldown-deliveries-quantity"><span class="quantity">{{ delivery.quantity|pretty_num }} {{ delivery.item }}</span>
+                <td class="drilldown-deliveries-quantity"><span class="quantity">{{ delivery.quantity|pretty_num }} {{ delivery.purchase.item|display_name }}</span>
                 </td>
                 <td class="drilldown-deliveries-desc">{{ delivery.description|default:"No description" }}</td>
                 <td class="drilldown-deliveries-vendor">{{delivery.vendor}}</td>
@@ -64,7 +63,7 @@
     <h2>Unscheduled Supply (Total: {{ unscheduled_total | pretty_num }})</h2>
     <ul>
         {% for purchase in purchases %}
-        {% if purchase.unscheduled_quantity %}
+        {% if purchase.unscheduled_quantity > 0 and purchase.quantity != purchase.received_quantity %}
         <li class="tooltip" aria-label="{{purchase.vendor}}">
             Receiving {{purchase.unscheduled_quantity|pretty_num}} {{ purchase.item }} –
             {{purchase.description|default:"No description"}}

--- a/nyc_data/ppe/views.py
+++ b/nyc_data/ppe/views.py
@@ -57,13 +57,15 @@ def drilldown(request):
     inventory = drilldown_res.inventory
     # deliveries_next_three = datetime.now() + timedelta(days=3)
 
+    past_deliveries = sum([d.quantity for d in deliveries if d.delivery_date <= datetime.now().date()])
+    received_deliveries = sum([p.received_quantity or 0 for p in purchases])
     context = {
         "asset_category": cat_display,
         # conversion to data class handles conversion to display names, etc.
-        "purchases": [p.to_dataclass() for p in purchases],
-        "deliveries": [d.to_dataclass() for d in deliveries],
+        "purchases": purchases,
+        "deliveries": deliveries,
         "inventory": inventory,
-        "deliveries_past": sum([d.quantity for d in deliveries if d.delivery_date <= datetime.now().date()]),
+        "deliveries_past": past_deliveries + received_deliveries,
         "deliveries_next_three": sum([d.quantity for d in deliveries if
                                       datetime.now().date() <= d.delivery_date <= datetime.now().date() + timedelta(
                                           days=3)]),
@@ -75,7 +77,6 @@ def drilldown(request):
                                            days=30)]),
         "scheduled_total": sum([d.quantity for d in deliveries]),
         "unscheduled_total": sum([purch.unscheduled_quantity for purch in purchases if purch.unscheduled_quantity]),
-        "received_total": sum([p.received_quantity or 0 for p in purchases]),
         "facility_deliveries": {k: v for k, v in
                                 aggregations.demand_for_period(datetime.now().date() - timedelta(days=7),
                                                                datetime.now().date(), lambda x: x).items() if

--- a/nyc_data/ppe/views.py
+++ b/nyc_data/ppe/views.py
@@ -57,7 +57,6 @@ def drilldown(request):
     inventory = drilldown_res.inventory
     # deliveries_next_three = datetime.now() + timedelta(days=3)
 
-    past_deliveries = sum([d.quantity for d in deliveries if d.delivery_date <= datetime.now().date()])
     received_deliveries = sum([p.received_quantity or 0 for p in purchases])
     context = {
         "asset_category": cat_display,
@@ -65,7 +64,7 @@ def drilldown(request):
         "purchases": purchases,
         "deliveries": deliveries,
         "inventory": inventory,
-        "deliveries_past": past_deliveries + received_deliveries,
+        "deliveries_past": received_deliveries,
         "deliveries_next_three": sum([d.quantity for d in deliveries if
                                       datetime.now().date() <= d.delivery_date <= datetime.now().date() + timedelta(
                                           days=3)]),


### PR DESCRIPTION
I think we can do a slightly better job of determining which deliveries are in the future and which are in the past by subtracting earlier deliveries from the received quantity, but I think this is OK for now.

* Add initial docs about mappers/importing
* Add `check_cached` to ensure we aren't running `O(n)` individual SQL queries
* filter unscheduled deliveries if there the received column shows we got it all
* Rather than show deliveries in the past (which I don't think are super valuable, we instead the value at `received` instead)

<img width="1273" alt="Screenshot 2020-04-13 12 06 39" src="https://user-images.githubusercontent.com/492903/79136614-4c247e00-7d7f-11ea-8c0d-8a4a9055c2c4.png">

