### PR TITLE
Add table to drilldown page & add support for date params

### DIFF
--- a/nyc_data/ppe/aggregations.py
+++ b/nyc_data/ppe/aggregations.py
@@ -32,7 +32,7 @@ DEMAND_MESSAGE = (
 class DemandCalculationConfig(NamedTuple):
     use_real_demand: bool = True
     use_hospitalization_projection: bool = True
-    rollup_fn: Callable[[dc.Item], str] = lambda x:x
+    rollup_fn: Callable[[dc.Item], str] = lambda x: x
 
 
 class DemandSrc(str, Enum):
@@ -91,11 +91,11 @@ MAPPING = {dc.OrderType.Make: "make", dc.OrderType.Purchase: "sell"}
 
 
 def asset_rollup_legacy(
-        time_start: datetime,
-        time_end: datetime,
-        use_hospitalization_projection=True,
-        use_real_demand=True,
-        rollup_fn: Callable[[dc.Item], str] = lambda x: x,
+    time_start: datetime,
+    time_end: datetime,
+    use_hospitalization_projection=True,
+    use_real_demand=True,
+    rollup_fn: Callable[[dc.Item], str] = lambda x: x,
 ):
     return asset_rollup(
         Period(time_start, time_end),
@@ -108,14 +108,13 @@ def asset_rollup_legacy(
 
 
 def asset_rollup(
-        time_range: Period,
-        demand_calculation_config: DemandCalculationConfig,
+    time_range: Period, demand_calculation_config: DemandCalculationConfig,
 ) -> Dict[str, AssetRollup]:
     time_start, time_end = time_range.start, time_range.end
     relevant_deliveries = (
         ScheduledDelivery.active()
-            .prefetch_related("purchase")
-            .filter(delivery_date__gte=time_start, delivery_date__lte=time_end)
+        .prefetch_related("purchase")
+        .filter(delivery_date__gte=time_start, delivery_date__lte=time_end)
     )
 
     results: Dict[dc.Item, AssetRollup] = {}
@@ -157,9 +156,9 @@ def deliveries_for_period(time_start: datetime, time_end: datetime):
     """
     demand_by_day = (
         FacilityDelivery.active()
-            .filter(date__gte=time_start, date__lte=time_end)
-            .values("item")
-            .annotate(Sum("quantity"))
+        .filter(date__gte=time_start, date__lte=time_end)
+        .values("item")
+        .annotate(Sum("quantity"))
     )
     rollup = collections.defaultdict(lambda: 0)
     for row in demand_by_day:
@@ -183,9 +182,9 @@ def known_recent_demand() -> Dict[dc.Item, Demand]:
 
 
 def compute_scaling_factor(
-        past_period: Period,
-        projection_period: Period,
-        demand_calculation_config: DemandCalculationConfig,
+    past_period: Period,
+    projection_period: Period,
+    demand_calculation_config: DemandCalculationConfig,
 ) -> float:
     if demand_calculation_config.use_hospitalization_projection:
         # Get last week'ks total hospitalization
@@ -201,10 +200,10 @@ def compute_scaling_factor(
 
 
 def add_demand_estimate(
-        time_start: datetime,
-        time_end: datetime,
-        asset_rollup: Dict[dc.Item, AssetRollup],
-        demand_calculation_config: DemandCalculationConfig,
+    time_start: datetime,
+    time_end: datetime,
+    asset_rollup: Dict[dc.Item, AssetRollup],
+    demand_calculation_config: DemandCalculationConfig,
 ):
     last_week_start = datetime.datetime.today() - datetime.timedelta(days=7)
     last_week_end = last_week_start + datetime.timedelta(days=6)

--- a/nyc_data/ppe/aggregations.py
+++ b/nyc_data/ppe/aggregations.py
@@ -2,7 +2,7 @@ import collections
 import datetime
 from dataclasses import dataclass, field
 from enum import Enum
-from typing import Dict, Callable, NamedTuple, Optional, List, Set
+from typing import Dict, Callable, NamedTuple, Set
 import json
 
 import django_tables2 as tables
@@ -10,10 +10,10 @@ from django.db.models import Sum
 from django.utils.html import format_html
 
 import ppe.dataclasses as dc
+from ppe.dataclasses import Period
 from ppe.models import (
     ScheduledDelivery,
     Inventory,
-    ImportStatus,
     FacilityDelivery,
     Demand,
 )
@@ -30,9 +30,9 @@ DEMAND_MESSAGE = (
 
 
 class DemandCalculationConfig(NamedTuple):
-    use_real_demand: bool
-    use_hospitalization_projection: bool
-    rollup_fn: Callable[[dc.Item], str]
+    use_real_demand: bool = True
+    use_hospitalization_projection: bool = True
+    rollup_fn: Callable[[dc.Item], str] = lambda x:x
 
 
 class DemandSrc(str, Enum):
@@ -90,16 +90,15 @@ class AssetRollup:
 MAPPING = {dc.OrderType.Make: "make", dc.OrderType.Purchase: "sell"}
 
 
-def asset_rollup(
-    time_start: datetime,
-    time_end: datetime,
-    use_hospitalization_projection=True,
-    use_real_demand=True,
-    rollup_fn: Callable[[dc.Item], str] = lambda x: x,
+def asset_rollup_legacy(
+        time_start: datetime,
+        time_end: datetime,
+        use_hospitalization_projection=True,
+        use_real_demand=True,
+        rollup_fn: Callable[[dc.Item], str] = lambda x: x,
 ):
-    return _asset_rollup(
-        time_start,
-        time_end,
+    return asset_rollup(
+        Period(time_start, time_end),
         DemandCalculationConfig(
             use_real_demand,
             use_hospitalization_projection=use_hospitalization_projection,
@@ -108,15 +107,15 @@ def asset_rollup(
     )
 
 
-def _asset_rollup(
-    time_start: datetime,
-    time_end: datetime,
-    demand_calculation_config: DemandCalculationConfig,
+def asset_rollup(
+        time_range: Period,
+        demand_calculation_config: DemandCalculationConfig,
 ) -> Dict[str, AssetRollup]:
+    time_start, time_end = time_range.start, time_range.end
     relevant_deliveries = (
         ScheduledDelivery.active()
-        .prefetch_related("purchase")
-        .filter(delivery_date__gte=time_start, delivery_date__lte=time_end)
+            .prefetch_related("purchase")
+            .filter(delivery_date__gte=time_start, delivery_date__lte=time_end)
     )
 
     results: Dict[dc.Item, AssetRollup] = {}
@@ -158,9 +157,9 @@ def deliveries_for_period(time_start: datetime, time_end: datetime):
     """
     demand_by_day = (
         FacilityDelivery.active()
-        .filter(date__gte=time_start, date__lte=time_end)
-        .values("item")
-        .annotate(Sum("quantity"))
+            .filter(date__gte=time_start, date__lte=time_end)
+            .values("item")
+            .annotate(Sum("quantity"))
     )
     rollup = collections.defaultdict(lambda: 0)
     for row in demand_by_day:
@@ -183,21 +182,10 @@ def known_recent_demand() -> Dict[dc.Item, Demand]:
     return recent_demands
 
 
-class Period(NamedTuple):
-    start: datetime.date
-    end: datetime.date
-
-    def inclusive_length(self):
-        return self.end - self.start + datetime.timedelta(days=1)
-
-    def exclusive_length(self):
-        return self.end - self.start
-
-
 def compute_scaling_factor(
-    past_period: Period,
-    projection_period: Period,
-    demand_calculation_config: DemandCalculationConfig,
+        past_period: Period,
+        projection_period: Period,
+        demand_calculation_config: DemandCalculationConfig,
 ) -> float:
     if demand_calculation_config.use_hospitalization_projection:
         # Get last week'ks total hospitalization
@@ -213,10 +201,10 @@ def compute_scaling_factor(
 
 
 def add_demand_estimate(
-    time_start: datetime,
-    time_end: datetime,
-    asset_rollup: Dict[dc.Item, AssetRollup],
-    demand_calculation_config: DemandCalculationConfig,
+        time_start: datetime,
+        time_end: datetime,
+        asset_rollup: Dict[dc.Item, AssetRollup],
+        demand_calculation_config: DemandCalculationConfig,
 ):
     last_week_start = datetime.datetime.today() - datetime.timedelta(days=7)
     last_week_end = last_week_start + datetime.timedelta(days=6)
@@ -258,7 +246,7 @@ def get_total_hospitalization(time_start: datetime, time_end: datetime) -> float
     total_hospitalization = 0
     date = time_start
     while date <= time_end:
-        hospitalization = HOSPITALIZATION[date.strftime("%Y-%m-%d")]
+        hospitalization = HOSPITALIZATION.get(date.strftime("%Y-%m-%d"))
         # Use All Beds Available (max during normal operation, not theoretical upper bounds) as lower bound
         if not hospitalization or hospitalization < ALL_BEDS_AVAILABLE:
             hospitalization = ALL_BEDS_AVAILABLE

--- a/nyc_data/ppe/data_mapping/utils.py
+++ b/nyc_data/ppe/data_mapping/utils.py
@@ -66,8 +66,8 @@ def parse_date(date: any, error_collector: ErrorCollector):
     formats = [
         ("%m/%d/%Y", lambda x: x),  # 04/10/2020
         ("%Y-%m-%d", lambda x: x),  # 2020-04-10
-        ("%d-%b", lambda d: d.replace(year=2020)),
-        ("%m/%d", lambda d: d.replace(year=2020)),
+        ("%d-%b", lambda d: d.replace(year=2020)),  # 30-Apr
+        ("%m/%d", lambda d: d.replace(year=2020)),  # 4/15
     ]
     if isinstance(date, str):
         for fmt, mapper in formats:

--- a/nyc_data/ppe/dataclasses.py
+++ b/nyc_data/ppe/dataclasses.py
@@ -1,5 +1,4 @@
-import datetime
-from datetime import datetime
+from datetime import datetime, timedelta, date
 from enum import Enum
 
 from dataclasses import dataclass
@@ -167,15 +166,15 @@ ITEM_TO_MAYORAL = {
 
 
 class Period(NamedTuple):
-    start: datetime.date
-    end: datetime.date
+    start: date
+    end: date
 
     @classmethod
     def last_week(cls):
-        return Period(datetime.today() - datetime.timedelta(days=6), datetime.today())
+        return Period(datetime.today() - timedelta(days=6), datetime.today())
 
     def inclusive_length(self):
-        return self.end - self.start + datetime.timedelta(days=1)
+        return self.end - self.start + timedelta(days=1)
 
     def exclusive_length(self):
         return self.end - self.start

--- a/nyc_data/ppe/dataclasses.py
+++ b/nyc_data/ppe/dataclasses.py
@@ -1,3 +1,4 @@
+import datetime
 from datetime import datetime
 from enum import Enum
 
@@ -163,3 +164,18 @@ ITEM_TO_MAYORAL = {
     Item.unknown: MayoralCategory.uncategorized,
     Item.body_bags: MayoralCategory.uncategorized,
 }
+
+
+class Period(NamedTuple):
+    start: datetime.date
+    end: datetime.date
+
+    @classmethod
+    def last_week(cls):
+        return Period(datetime.today() - datetime.timedelta(days=6), datetime.today())
+
+    def inclusive_length(self):
+        return self.end - self.start + datetime.timedelta(days=1)
+
+    def exclusive_length(self):
+        return self.end - self.start

--- a/nyc_data/ppe/drilldown.py
+++ b/nyc_data/ppe/drilldown.py
@@ -1,31 +1,40 @@
 import ppe.dataclasses as dc
-from datetime import datetime
+from datetime import datetime, timedelta
 
+from ppe import aggregations
+from ppe.aggregations import AssetRollup, DemandCalculationConfig
 from ppe.models import ScheduledDelivery, Purchase, Inventory
-from typing import List, Callable, NamedTuple
+from typing import List, Callable, NamedTuple, Dict
 
 
 class DrilldownResult(NamedTuple):
     purchases: List[Purchase]
     scheduled_deliveries: List[ScheduledDelivery]
     inventory: List[Inventory]
+    aggregation: Dict[str, AssetRollup]
 
 
-def drilldown_result(item_type: str, rollup_fn: Callable[[dc.Item], str]):
+def drilldown_result(item_type: str, rollup_fn: Callable[[dc.Item], str],
+                     time_range: dc.Period = None):
     # could do this in SQL but probably unecessary
+    if time_range is None:
+        time_range = dc.Period(datetime.today(), datetime.today() + timedelta(days=30))
     purchases = (
         Purchase.active()
-        .prefetch_related("deliveries")
-        .order_by("deliveries__delivery_date")
+            .prefetch_related("deliveries")
+            .order_by("deliveries__delivery_date")
     )
     purchases = [p for p in purchases if rollup_fn(dc.Item(p.item)) == item_type]
     deliveries = (
         ScheduledDelivery.active()
-        .prefetch_related("purchase")
-        .order_by("delivery_date")
+            .prefetch_related("purchase")
+            .order_by("delivery_date")
     )
     deliveries = [d for d in deliveries if rollup_fn(dc.Item(d.item)) == item_type]
     inventory = [
         i for i in Inventory.active() if rollup_fn(dc.Item(i.item)) == item_type
     ]
-    return DrilldownResult(purchases, deliveries, inventory)
+
+    aggregation = aggregations.asset_rollup(time_range=time_range, demand_calculation_config=DemandCalculationConfig())
+    filtered_aggregation = {item: agg for item, agg in aggregation.items() if rollup_fn(item) == item_type}
+    return DrilldownResult(purchases, deliveries, inventory, aggregation=filtered_aggregation)

--- a/nyc_data/ppe/drilldown.py
+++ b/nyc_data/ppe/drilldown.py
@@ -14,27 +14,34 @@ class DrilldownResult(NamedTuple):
     aggregation: Dict[str, AssetRollup]
 
 
-def drilldown_result(item_type: str, rollup_fn: Callable[[dc.Item], str],
-                     time_range: dc.Period = None):
+def drilldown_result(
+    item_type: str, rollup_fn: Callable[[dc.Item], str], time_range: dc.Period = None
+):
     # could do this in SQL but probably unecessary
     if time_range is None:
         time_range = dc.Period(datetime.today(), datetime.today() + timedelta(days=30))
     purchases = (
         Purchase.active()
-            .prefetch_related("deliveries")
-            .order_by("deliveries__delivery_date")
+        .prefetch_related("deliveries")
+        .order_by("deliveries__delivery_date")
     )
     purchases = [p for p in purchases if rollup_fn(dc.Item(p.item)) == item_type]
     deliveries = (
         ScheduledDelivery.active()
-            .prefetch_related("purchase")
-            .order_by("delivery_date")
+        .prefetch_related("purchase")
+        .order_by("delivery_date")
     )
     deliveries = [d for d in deliveries if rollup_fn(dc.Item(d.item)) == item_type]
     inventory = [
         i for i in Inventory.active() if rollup_fn(dc.Item(i.item)) == item_type
     ]
 
-    aggregation = aggregations.asset_rollup(time_range=time_range, demand_calculation_config=DemandCalculationConfig())
-    filtered_aggregation = {item: agg for item, agg in aggregation.items() if rollup_fn(item) == item_type}
-    return DrilldownResult(purchases, deliveries, inventory, aggregation=filtered_aggregation)
+    aggregation = aggregations.asset_rollup(
+        time_range=time_range, demand_calculation_config=DemandCalculationConfig()
+    )
+    filtered_aggregation = {
+        item: agg for item, agg in aggregation.items() if rollup_fn(item) == item_type
+    }
+    return DrilldownResult(
+        purchases, deliveries, inventory, aggregation=filtered_aggregation
+    )

--- a/nyc_data/ppe/optimization.py
+++ b/nyc_data/ppe/optimization.py
@@ -1,8 +1,9 @@
 from ortools.linear_solver import pywraplp
-from datetime import datetime
-from datetime import timedelta
+from datetime import timedelta, datetime, date
+import ppe.dataclasses as dc
+from ppe import aggregations
+from ppe.aggregations import compute_scaling_factor, DemandCalculationConfig
 from ppe.dataclasses import Forecast
-
 
 # For each day and each type of resource, I am think of modeling with the following four variables (day N):
 # demand_N : demand of this day.
@@ -16,10 +17,42 @@ from ppe.dataclasses import Forecast
 # inventory_N  will be estimated by the LP model.
 
 # The type of constraints would be very simple at the beginning: just day-to-day consistency: inventory_N + supply_N + additional_supply_N - demand_(N+1) = inventory_(N+1)
+from ppe.models import Inventory, ScheduledDelivery
+
+
+def generate_forecast_for_item(start_date: date, item: dc.Item, n_days: int = 100):
+    demand_data = aggregations.known_recent_demand()
+    if item not in demand_data:
+        return None
+    else:
+        demand_for_asset = demand_data[item]
+    start_inventory = Inventory.active().filter(item=item).first().quantity
+    future_deliveries = ScheduledDelivery.active().filter(purchase__item=item, delivery_date__gte=start_date)
+    # 100 days
+    future_supply = [0] * n_days
+    demand_forecast = [0] * n_days
+
+    for delivery in future_deliveries:
+        day = (delivery.delivery_date - start_date).days
+        if day > 0 and day < len(future_supply):
+            future_supply[day] += delivery.quantity
+
+    for day in range(n_days):
+        day_of = start_date + timedelta(days=day)
+        scaling_factor = compute_scaling_factor(
+            past_period=dc.Period(
+                demand_for_asset.start_date, demand_for_asset.end_date
+            ),
+            projection_period=dc.Period(day_of, day_of + timedelta(days=1)),
+            demand_calculation_config=DemandCalculationConfig(),
+        )
+        import pdb; pdb.set_trace()
+        demand_forecast[day] += int(scaling_factor * demand_for_asset.demand)
+
+    return generate_forecast(start_date, start_inventory, demand_forecast, future_supply)
 
 
 def generate_forecast(start_date, start_inventory, demand_forecast, known_supply):
-
     # Create the linear solver with the GLOP backend.
     solver = pywraplp.Solver(
         "simple_lp_program", pywraplp.Solver.GLOP_LINEAR_PROGRAMMING
@@ -82,10 +115,12 @@ def generate_forecast(start_date, start_inventory, demand_forecast, known_supply
     objective.SetMinimization()
 
     status = solver.Solve()
+    import pdb; pdb.set_trace()
     if status != pywraplp.Solver.OPTIMAL:
         return []
 
     forecast_result = []
+    import pdb; pdb.set_trace()
     for day in days:
         forecast_result.append(
             Forecast(

--- a/nyc_data/ppe/optimization.py
+++ b/nyc_data/ppe/optimization.py
@@ -27,7 +27,9 @@ def generate_forecast_for_item(start_date: date, item: dc.Item, n_days: int = 10
     else:
         demand_for_asset = demand_data[item]
     start_inventory = Inventory.active().filter(item=item).first().quantity
-    future_deliveries = ScheduledDelivery.active().filter(purchase__item=item, delivery_date__gte=start_date)
+    future_deliveries = ScheduledDelivery.active().filter(
+        purchase__item=item, delivery_date__gte=start_date
+    )
     # 100 days
     future_supply = [0] * n_days
     demand_forecast = [0] * n_days
@@ -46,10 +48,14 @@ def generate_forecast_for_item(start_date: date, item: dc.Item, n_days: int = 10
             projection_period=dc.Period(day_of, day_of + timedelta(days=1)),
             demand_calculation_config=DemandCalculationConfig(),
         )
-        import pdb; pdb.set_trace()
+        import pdb
+
+        pdb.set_trace()
         demand_forecast[day] += int(scaling_factor * demand_for_asset.demand)
 
-    return generate_forecast(start_date, start_inventory, demand_forecast, future_supply)
+    return generate_forecast(
+        start_date, start_inventory, demand_forecast, future_supply
+    )
 
 
 def generate_forecast(start_date, start_inventory, demand_forecast, known_supply):
@@ -115,12 +121,16 @@ def generate_forecast(start_date, start_inventory, demand_forecast, known_supply
     objective.SetMinimization()
 
     status = solver.Solve()
-    import pdb; pdb.set_trace()
+    import pdb
+
+    pdb.set_trace()
     if status != pywraplp.Solver.OPTIMAL:
         return []
 
     forecast_result = []
-    import pdb; pdb.set_trace()
+    import pdb
+
+    pdb.set_trace()
     for day in days:
         forecast_result.append(
             Forecast(

--- a/nyc_data/ppe/templates/dashboard.html
+++ b/nyc_data/ppe/templates/dashboard.html
@@ -2,7 +2,7 @@
 {% load render_table from django_tables2 %}
 
 {% block titlebar %}
-<h2>Current status including all sources for the next 30 days</h2>
+<h2>Current status including all sources for the next {{ days_in_view }} days</h2>
 <div class="view-options">
     <div id="rollup-options" class="toggle">
         <label>View as</label>

--- a/nyc_data/ppe/templates/drilldown.html
+++ b/nyc_data/ppe/templates/drilldown.html
@@ -1,26 +1,22 @@
 {% extends "base.html" %}
 {% load ppe_extras %}
+{% load render_table from django_tables2 %}
 
 {% block titlebar %}
-<h2>{{ asset_category }}</h2>
+<h2>{{ asset_category|display_name }}</h2>
 {% endblock %}
 
 {% block content %}
+{% render_table aggregations %}
 <div class="incoming-supply">
     <div>
-        <h2>Current Inventory</h2>
-        <ul>
-            {%for item in inventory %}
-            <li>{{item.item|display_name}}: {{item.quantity|pretty_num}}</li>
-            {% endfor %}
-        </ul>
-        <h4>Disbursed to facilities (hospitals, nursing homes, etc.) last 7 days</h4>
+        <!--<h4>Disbursed to facilities (hospitals, nursing homes, etc.) last 7 days</h4>
         <ul>
             {%for item, ct in facility_deliveries.items%}
             <li>{{item|display_name}}: {{ct|pretty_num}}</li>
             {% endfor %}
         </ul>
-        <hr/>
+        <hr/>-->
     </div>
 
     <div class="drilldown-detail supply-scheduled">

--- a/nyc_data/ppe/templatetags/ppe_extras.py
+++ b/nyc_data/ppe/templatetags/ppe_extras.py
@@ -1,7 +1,7 @@
 from django import template
 
 from ppe.aggregations import split_value_unit
-from ppe.dataclasses import Item
+from ppe.dataclasses import Item, MayoralCategory
 
 register = template.Library()
 
@@ -12,7 +12,17 @@ def pretty_num(value):
 
 
 def display_name(value):
-    return Item(value).display()
+    try:
+        return MayoralCategory(value).value
+    except ValueError:
+        pass
+
+    try:
+        return Item(value).display()
+    except ValueError:
+        pass
+    # we give up
+    return value
 
 
 register.filter("pretty_num", pretty_num)

--- a/nyc_data/ppe/tests.py
+++ b/nyc_data/ppe/tests.py
@@ -5,7 +5,8 @@ from django.test import TestCase, override_settings
 from django.urls import reverse
 
 from ppe import aggregations
-from ppe.aggregations import AssetRollup, DemandSrc, Period
+from ppe.aggregations import AssetRollup, DemandSrc
+from ppe.dataclasses import Period
 from ppe.data_mapping.types import DataFile
 from ppe.data_mapping.mappers.dcas_sourcing import SourcingRow
 from ppe.data_mapping.mappers.hospital_demands import DemandRow
@@ -98,7 +99,7 @@ class TestAssetRollup(TestCase):
 
     def test_rollup(self):
         today = datetime(2020, 4, 12)
-        rollup = aggregations.asset_rollup(today - timedelta(days=27), today)
+        rollup = aggregations.asset_rollup_legacy(today - timedelta(days=27), today)
         self.assertEqual(len(rollup), len(dc.Item))
         # demand of 20 = 5 in the last week * 4 weeks in the period
         self.assertEqual(
@@ -113,7 +114,7 @@ class TestAssetRollup(TestCase):
         )
 
         # Turn off use of hospitalization projection
-        rollup = aggregations.asset_rollup(
+        rollup = aggregations.asset_rollup_legacy(
             today - timedelta(days=27), today, use_hospitalization_projection=False,
         )
         self.assertEqual(
@@ -140,7 +141,7 @@ class TestAssetRollup(TestCase):
         )
 
         # Turn of use off hospitalization projection & real demand
-        future_rollup = aggregations.asset_rollup(
+        future_rollup = aggregations.asset_rollup_legacy(
             today,
             today + timedelta(days=27),
             use_hospitalization_projection=False,
@@ -161,7 +162,7 @@ class TestAssetRollup(TestCase):
 
     def test_mayoral_rollup(self):
         today = datetime(2020, 4, 12)
-        rollup = aggregations.asset_rollup(
+        rollup = aggregations.asset_rollup_legacy(
             today - timedelta(days=27),
             today,
             rollup_fn=lambda row: row.to_mayoral_category(),
@@ -178,7 +179,7 @@ class TestAssetRollup(TestCase):
         self.data_import.save()
         try:
             self.assertEqual(aggregations.known_recent_demand(), {})
-            rollup = aggregations.asset_rollup(today - timedelta(days=28), today)
+            rollup = aggregations.asset_rollup_legacy(today - timedelta(days=28), today)
             self.assertEqual(
                 rollup[dc.Item.gown], AssetRollup(asset=dc.Item.gown, demand=0, sell=0)
             )

--- a/nyc_data/ppe/views.py
+++ b/nyc_data/ppe/views.py
@@ -1,5 +1,5 @@
-from datetime import datetime, timedelta
-from typing import NamedTuple, Optional
+from datetime import datetime, timedelta, date
+from typing import NamedTuple, Optional, Callable
 
 from django.http import HttpResponse, JsonResponse
 from django.forms import Form
@@ -9,31 +9,57 @@ from django.urls import reverse
 from django.views import View
 from django_tables2 import RequestConfig
 
-from ppe import aggregations, dataclasses as dc
+from ppe import aggregations, dataclasses as dc, optimization
 from ppe import forms, data_import
+from ppe.data_mapping.utils import parse_date, ErrorCollector
 from ppe.drilldown import drilldown_result
 from ppe.models import DataImport
 from ppe.optimization import generate_forecast
 
 
-def mayoral_rollup(row):
+def mayoral_rollup(row: str):
     return dc.Item(row).to_mayoral_category()
 
 
-def default(request):
-    if request.GET.get("rollup", "") in ["mayoral", "", None]:
-        aggregation = aggregations.asset_rollup(
-            time_start=datetime.now(),
-            time_end=datetime.now() + timedelta(days=30),
-            rollup_fn=mayoral_rollup,
-        )
-    elif request.GET.get("rollup", "") in [
-        "critical",
-    ]:
-        aggregation = aggregations.asset_rollup(
-            datetime.now(), datetime.now() + timedelta(days=30)
+class StandardRequestParams(NamedTuple):
+    start_date: date  # usually today
+    end_date: date  # usually today + n days
+    rollup_fn: Callable[[str], str]
+
+    @classmethod
+    def load_from_request(cls, request) -> 'StandardRequestParams':
+        if request.GET:
+            params = request.GET
+        else:
+            params = request.POST
+
+        start_date = params.get('start_date')
+        end_date = params.get('end_date')
+
+        err_collector = ErrorCollector()
+        start_date = parse_date(start_date, err_collector) or date.today()
+        end_date = parse_date(end_date, err_collector) or date.today() + timedelta(days=29)
+
+        if params.get("rollup") in {"mayoral", "", None}:
+            rollup_fn = mayoral_rollup
+        else:
+            rollup_fn = lambda x: x
+
+        return StandardRequestParams(
+            start_date=start_date,
+            end_date=end_date,
+            rollup_fn=rollup_fn
         )
 
+
+def default(request):
+    params = StandardRequestParams.load_from_request(request)
+
+    aggregation = aggregations.asset_rollup_legacy(
+        time_start=params.start_date,
+        time_end=params.end_date,
+        rollup_fn=params.rollup_fn,
+    )
     displayed_vals = ["donate", "sell", "make", "inventory"]
     cleaned_aggregation = [
         rollup
@@ -48,24 +74,29 @@ def default(request):
 
 
 def drilldown(request):
+    params = StandardRequestParams.load_from_request(request)
     category = request.GET.get("category")
     if category is None:
         return HttpResponse("Need an asset category param", status=400)
-    if request.GET.get("rollup") == "mayoral":
-        rollup = mayoral_rollup
-        cat_display = category
-    else:
-        rollup = lambda x: x
-        cat_display = dc.Item(category).display()
-    drilldown_res = drilldown_result(category, rollup)
+
+    drilldown_res = drilldown_result(category, params.rollup_fn)
+    table = aggregations.AggregationTable(drilldown_res.aggregation.values())
+    RequestConfig(request).configure(table)
     purchases = drilldown_res.purchases
     deliveries = drilldown_res.scheduled_deliveries
     inventory = drilldown_res.inventory
     # deliveries_next_three = datetime.now() + timedelta(days=3)
+    for inventory_row in inventory:
+        forecast = optimization.generate_forecast_for_item(params.start_date, inventory_row.item)
+        print(forecast)
+        import pdb; pdb.set_trace()
+
+
 
     received_deliveries = sum([p.received_quantity or 0 for p in purchases])
     context = {
-        "asset_category": cat_display,
+        "aggregations": table,
+        "asset_category": category,
         # conversion to data class handles conversion to display names, etc.
         "purchases": purchases,
         "deliveries": deliveries,
@@ -76,8 +107,8 @@ def drilldown(request):
                 d.quantity
                 for d in deliveries
                 if datetime.now().date()
-                <= d.delivery_date
-                <= datetime.now().date() + timedelta(days=2)
+                   <= d.delivery_date
+                   <= datetime.now().date() + timedelta(days=2)
             ]
         ),
         "deliveries_next_week": sum(
@@ -85,8 +116,8 @@ def drilldown(request):
                 d.quantity
                 for d in deliveries
                 if datetime.now().date()
-                <= d.delivery_date
-                <= datetime.now().date() + timedelta(days=6)
+                   <= d.delivery_date
+                   <= datetime.now().date() + timedelta(days=6)
             ]
         ),
         "deliveries_next_thirty": sum(
@@ -94,8 +125,8 @@ def drilldown(request):
                 d.quantity
                 for d in deliveries
                 if datetime.now().date()
-                <= d.delivery_date
-                <= datetime.now().date() + timedelta(days=29)
+                   <= d.delivery_date
+                   <= datetime.now().date() + timedelta(days=29)
             ]
         ),
         "scheduled_total": sum([d.quantity for d in deliveries]),
@@ -111,7 +142,7 @@ def drilldown(request):
             for k, v in aggregations.deliveries_for_period(
                 datetime.now().date() - timedelta(days=6), datetime.now().date()
             ).items()
-            if rollup(k) == category
+            if params.rollup_fn(k) == category
         },
     }
     return render(request, "drilldown.html", context)

--- a/nyc_data/xlsx_utils.py
+++ b/nyc_data/xlsx_utils.py
@@ -56,7 +56,7 @@ def guess_mapping(sheet: Path, possible_mappings: List[SheetMapping]):
             first_row = next(XLSXDictReader(sheet))
         else:
 
-            with open(sheet, "r", encoding="utf16") as csvfile:
+            with open(sheet) as csvfile:
                 text = csvfile.read()
             reader = csv.DictReader(text.splitlines())
             first_row = next(reader)


### PR DESCRIPTION
I got a little distracted and started working on plugging our data in @yu-peng's forecast code which pretty quickly hit some issues he's looking into. But then I remembered what I was doing and:
* Added support for time range parameters `start_date` and `end_date`. For convenience, they use the same date parsers we use for the spread sheets: 
```python
    formats = [
        ("%m/%d/%Y", lambda x: x),  # 04/10/2020
        ("%Y-%m-%d", lambda x: x),  # 2020-04-10
        ("%d-%b", lambda d: d.replace(year=2020)),  # 30-Apr
        ("%m/%d", lambda d: d.replace(year=2020)),  # 4/15
    ]
```
If you need a different format, just add it to that list. 

* Added a table to the drilldown page. It will show all assets in the category exactly the same as the home page and will support the same time range parameters. _Links into the drilldowns preserve url parameters_ (which is mostly useful for the time range).
 

<img width="1185" alt="Screenshot 2020-04-14 21 27 32" src="https://user-images.githubusercontent.com/492903/79293128-d9abbf00-7ea0-11ea-8569-39c9ac512989.png">
