### PR TITLE
Show NYC time in upload form

### DIFF
--- a/nyc_data/ppe/templates/verify_upload.html
+++ b/nyc_data/ppe/templates/verify_upload.html
@@ -1,4 +1,5 @@
 {% extends "base.html" %}
+{% load tz %}
 
 {% block titlebar %}
 <h2>Confirm your upload</h2>
@@ -9,7 +10,9 @@
     <div class="upload-details" style="width: 50%;">
         <p>Replacing upload by:</p>
         <ul>
+            {% timezone 'America/New_York' %}
             <li>{{ delta.previous.uploaded_by | default:"Unknown user" }} on {{ delta.previous.import_date }}</li>
+            {% endtimezone %}
         </ul>
         <dl>
             <li>


### PR DESCRIPTION
Show the upload time in NY time to avoid confusion. Previously I think it was in GMT or something.
<img width="399" alt="Screenshot 2020-04-15 11 48 04" src="https://user-images.githubusercontent.com/492903/79358265-fbdc2600-7f0e-11ea-94c4-eb36613f216b.png">
