### PR TITLE
Add date picker to dashboard and drilldown

### DIFF
--- a/nyc_data/ppe/static/script.js
+++ b/nyc_data/ppe/static/script.js
@@ -41,7 +41,7 @@ $(function(){
         function cb(start, end) {
             var newloc;
 
-            $('#reportrange span').html(start.format('MMM D') + ' - ' + end.format('MMM D'));
+            $('#reportrange span').html(start.format('MMM D') + ' – ' + end.format('MMM D'));
             searchParams.set('start_date', start.format('YYYY-MM-DD'));
             searchParams.set('end_date', end.format('YYYY-MM-DD'));
 

--- a/nyc_data/ppe/static/script.js
+++ b/nyc_data/ppe/static/script.js
@@ -1,5 +1,6 @@
+var searchParams = new URLSearchParams(window.location.search);
+
 function addUrlParameter(name, value) {
-    var searchParams = new URLSearchParams(window.location.search);
     searchParams.set(name, value);
     window.location.search = searchParams.toString();
 }
@@ -29,4 +30,41 @@ $(function(){
         });
     }
 
+
+    // Datepicker
+    $(function() {
+        var start, end;
+
+        start = searchParams.get('start_date') ? moment(searchParams.get('start_date')) : moment();
+        end = searchParams.get('end_date') ? moment(searchParams.get('end_date')) : moment().add(29, 'days');
+    
+        function cb(start, end) {
+            var newloc;
+
+            $('#reportrange span').html(start.format('MMM D') + ' - ' + end.format('MMM D'));
+            searchParams.set('start_date', start.format('YYYY-MM-DD'));
+            searchParams.set('end_date', end.format('YYYY-MM-DD'));
+
+            newloc = searchParams.toString();
+            if (newloc != window.location.search.replace('?','')) {
+                window.location.search = newloc;
+            }
+        }
+    
+        $('#reportrange').daterangepicker({
+            startDate: start,
+            endDate: end,
+            ranges: {
+                'This Week': [moment().startOf('week'), moment().endOf('week')],
+                'Next Week': [moment().add(1, 'week').startOf('week'), moment().add(1, 'week').endOf('week')],
+                'Next 7 Days': [moment(), moment().add(6, 'days')],
+                'Next 30 Days': [moment(), moment().add(29, 'days')],
+                'This Month': [moment().startOf('month'), moment().endOf('month')],
+                'Next Month': [moment().add(1, 'month').startOf('month'), moment().add(1, 'month').endOf('month')]
+            }
+        }, cb);
+    
+        cb(start, end);
+    
+    });
 });

--- a/nyc_data/ppe/static/style.css
+++ b/nyc_data/ppe/static/style.css
@@ -15,7 +15,7 @@ a:hover {
 }
 
 section.container {
-    width: 80%;
+    width: 90%;
     margin: 0 auto;
 }
 
@@ -466,6 +466,15 @@ body.drilldown .dashboard-table {
 #reportrange {
     display: inline-block;
     cursor: pointer;
+}
+
+#reportrange::after {
+    display: inline-block;
+    content: "▼";
+    font-size: 14px;
+    margin-left: 5px;
+    vertical-align: middle;
+    color: #999;
 }
 
 #reportrange span {

--- a/nyc_data/ppe/static/style.css
+++ b/nyc_data/ppe/static/style.css
@@ -385,7 +385,7 @@ body.drilldown .dashboard-table {
     background: #fafafa;
 }
 
-.dashboard-table th, td {
+.dashboard-table th, .dashboard-table td {
     padding-right: 20px;
     padding-top: 16px;
     padding-bottom: 16px;
@@ -459,4 +459,32 @@ body.drilldown .dashboard-table {
     font-weight: 300;
     color: #888;
     font-size: 14px;
+}
+
+/* Datepicker styles */
+
+#reportrange span {
+    text-decoration: underline;
+    color: #000;
+}
+
+.daterangepicker td.active, .daterangepicker td.active:hover {
+    background-color: #0a5796;
+}
+
+.daterangepicker .ranges li.active {
+    background-color: #0a5796;
+}
+
+.daterangepicker .drp-buttons .btn {
+    background: #eee;
+    border: 1px solid #ddd;
+    border-radius: 20px;
+    font-weight: 300;
+}
+
+.daterangepicker .drp-buttons .btn-primary {
+    background: #0a5796;
+    border: 1px solid #ddd;
+    color: #fff;
 }

--- a/nyc_data/ppe/static/style.css
+++ b/nyc_data/ppe/static/style.css
@@ -463,6 +463,11 @@ body.drilldown .dashboard-table {
 
 /* Datepicker styles */
 
+#reportrange {
+    display: inline-block;
+    cursor: pointer;
+}
+
 #reportrange span {
     text-decoration: underline;
     color: #000;

--- a/nyc_data/ppe/templates/base.html
+++ b/nyc_data/ppe/templates/base.html
@@ -2,7 +2,11 @@
 <html>
 <head>
     <title>{% block titleprefix %}{% endblock %}NYC PPE Data</title>
+    <link rel="stylesheet" type="text/css" href="https://cdn.jsdelivr.net/npm/daterangepicker/daterangepicker.css" />
     <link rel="stylesheet" type="text/css" href="{% static 'style.css' %}">
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.5.0/jquery.slim.min.js" integrity="sha256-MlusDLJIP1GRgLrOflUQtshyP0TwT/RHXsI1wWGnQhs=" crossorigin="anonymous"></script>
+    <script type="text/javascript" src="https://cdn.jsdelivr.net/momentjs/latest/moment.min.js"></script>
+    <script type="text/javascript" src="https://cdn.jsdelivr.net/npm/daterangepicker/daterangepicker.min.js"></script>
 </head>
 <body class="{% block bodyclass %}{% endblock %}">
     <section class="disclaimer">
@@ -29,7 +33,6 @@
             {% block footer %}{% endblock %}
         </section>
     </section>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.5.0/jquery.slim.min.js" integrity="sha256-MlusDLJIP1GRgLrOflUQtshyP0TwT/RHXsI1wWGnQhs=" crossorigin="anonymous"></script>
     <script src="{% static 'script.js' %}"></script>
 </body>
 </html>

--- a/nyc_data/ppe/templates/dashboard.html
+++ b/nyc_data/ppe/templates/dashboard.html
@@ -3,7 +3,7 @@
 
 {% block titlebar %}
 <h2>
-    Current status including all sources for <div id="reportrange"><span></span></div>
+    Current status for <div id="reportrange"><span></span></div>
 </h2>
 
 <div class="view-options">

--- a/nyc_data/ppe/templates/dashboard.html
+++ b/nyc_data/ppe/templates/dashboard.html
@@ -3,10 +3,7 @@
 
 {% block titlebar %}
 <h2>
-    Current status including all sources for 
-    <div id="reportrange" style="display: inline-block; cursor: pointer; padding: 5px 10px;">
-        <span></span>
-    </div>
+    Current status including all sources for <div id="reportrange"><span></span></div>
 </h2>
 
 <div class="view-options">

--- a/nyc_data/ppe/templates/dashboard.html
+++ b/nyc_data/ppe/templates/dashboard.html
@@ -2,7 +2,13 @@
 {% load render_table from django_tables2 %}
 
 {% block titlebar %}
-<h2>Current status including all sources for the next {{ days_in_view }} days</h2>
+<h2>
+    Current status including all sources for 
+    <div id="reportrange" style="display: inline-block; cursor: pointer; padding: 5px 10px;">
+        <span></span>
+    </div>
+</h2>
+
 <div class="view-options">
     <div id="rollup-options" class="toggle">
         <label>View as</label>

--- a/nyc_data/ppe/templates/drilldown.html
+++ b/nyc_data/ppe/templates/drilldown.html
@@ -5,7 +5,9 @@
 {% block bodyclass %}drilldown{% endblock %}
 
 {% block titlebar %}
-<h2>{{ asset_category|display_name }}</h2>
+<h2>
+    {{ asset_category|display_name }} status for <div id="reportrange"><span></span></div>
+</h2>
 {% endblock %}
 
 {% block content %}


### PR DESCRIPTION
Defaults should be set up sensibly, and it should play well with existing date practices, including defaulting to next 30 days.

<img width="1279" alt="Screen Shot 2020-04-16 at 8 06 08 AM" src="https://user-images.githubusercontent.com/69848/79454389-22ef3200-7fb9-11ea-96cb-551bd480310a.png">
