### PR TITLE
Add donation metadata to dashboard/footer

### DIFF
--- a/nyc_data/ppe/aggregations.py
+++ b/nyc_data/ppe/aggregations.py
@@ -330,7 +330,14 @@ class AggregationTable(tables.Table):
             }
         }
     )
-    donate = NumericalColumn()
+    donate = NumericalColumn(verbose_name="Donated",
+        attrs={
+            "th": {
+                "class": "tooltip",
+                "aria-label": lambda: f"DCAS pending pledges [{current_as_of(Purchase.active().filter(order_type=dc.OrderType.Donation))}]",
+            },
+        },
+    )
     sell = NumericalColumn(
         verbose_name="Ordered",
         attrs={

--- a/nyc_data/ppe/templates/base.html
+++ b/nyc_data/ppe/templates/base.html
@@ -30,7 +30,25 @@
     </section> 
     <section class="footer">
         <section class="container">
-            {% block footer %}{% endblock %}
+            {% block footer %}
+            <dl>
+                <dt>Demand</dt>
+                <dd>A proxy for future demand, calculated by considering the previous 7 day's deliveries to hospitals,
+                    extrapolated with CovidActNow (https://covidactnow.org/)'s model for NYC to project future demand.</dd>
+                <dt>Supply</dt>
+                <dd>The sum of inventory, purchasing (Ordered), and manufacturing (Made) efforts.</dd>
+                <dt>Balance</dt>
+                <dd>The supply deficit or surplus compared to demand, both numerically and as a percentage.</dd>
+                <dt>Inventory</dt>
+                <dd>Daily inventory numbers from DOHMH. <a href="mailto:kbrown@cityops.nyc.gov?subject=NYCPPE%20Data%20Update%20Requested&body=Please%20update%20the%20DOHMH%20inventory%20data%20at%20your%20earliest%20convenience.">[Request update]</a></dd>
+                <dt>Ordered</dt>
+                <dd>Purchase orders for future deliveries with a known future delivery date from DCAS. <a href="mailto:brandon.chiazza@mocs.nyc.gov?subject=NYCPPE%20Data%20Update%20Requested&body=Please%20update%20the%20DCAS%20ordering%20charts%20data%20at%20your%20earliest%20convenience.">[Request update]</a></dd>
+                <dt>Make</dt>
+                <dd>Purchase orders for manufacturing, from EDC. <a href="mailto:tchilds@edc.nyc?subject=NYCPPE%20Data%20Update%20Requested&body=Please%20update%20the%20EDC%20PPE%20data%20at%20your%20earliest%20convenience.">[Request update]</a></dd>
+                <dt>Donate</dt>
+                <dd>Pledged donations that have not yet been received, from DCAS. <a href="mailto:awichowski@cto.nyc.gov?subject=NYCPPE%20Data%20Update%20Requested&body=Please%20update%20the%20EDC%20PPE%20data%20at%20your%20earliest%20convenience.">[Request update]</a></dd>
+            </dl>
+            {% endblock %}
         </section>
     </section>
     <script src="{% static 'script.js' %}"></script>

--- a/nyc_data/ppe/templates/dashboard.html
+++ b/nyc_data/ppe/templates/dashboard.html
@@ -38,6 +38,8 @@
     <dd>Purchase orders for future deliveries with a known future delivery date from DCAS. <a href="mailto:brandon.chiazza@mocs.nyc.gov?subject=NYCPPE%20Data%20Update%20Requested&body=Please%20update%20the%20DCAS%20ordering%20charts%20data%20at%20your%20earliest%20convenience.">[Request update]</a></dd>
     <dt>Make</dt>
     <dd>Purchase orders for manufacturing, from EDC. <a href="mailto:tchilds@edc.nyc?subject=NYCPPE%20Data%20Update%20Requested&body=Please%20update%20the%20EDC%20PPE%20data%20at%20your%20earliest%20convenience.">[Request update]</a></dd>
+    <dt>Donate</dt>
+    <dd>Pledged donations that have not yet been received, from DCAS. <a href="mailto:awichowski@cto.nyc.gov?subject=NYCPPE%20Data%20Update%20Requested&body=Please%20update%20the%20EDC%20PPE%20data%20at%20your%20earliest%20convenience.">[Request update]</a></dd>
 </dl>
 
 {% endblock %}

--- a/nyc_data/ppe/templates/dashboard.html
+++ b/nyc_data/ppe/templates/dashboard.html
@@ -22,24 +22,3 @@
     {% render_table aggregations %}
 </div>
 {% endblock %}
-
-{% block footer %}
-<dl>
-    <dt>Demand</dt>
-    <dd>A proxy for future demand, calculated by considering the previous 7 day's deliveries to hospitals,
-        extrapolated with CovidActNow (https://covidactnow.org/)'s model for NYC to project future demand.</dd>
-    <dt>Supply</dt>
-    <dd>The sum of inventory, purchasing (Ordered), and manufacturing (Made) efforts.</dd>
-    <dt>Balance</dt>
-    <dd>The supply deficit or surplus compared to demand, both numerically and as a percentage.</dd>
-    <dt>Inventory</dt>
-    <dd>Daily inventory numbers from DOHMH. <a href="mailto:kbrown@cityops.nyc.gov?subject=NYCPPE%20Data%20Update%20Requested&body=Please%20update%20the%20DOHMH%20inventory%20data%20at%20your%20earliest%20convenience.">[Request update]</a></dd>
-    <dt>Ordered</dt>
-    <dd>Purchase orders for future deliveries with a known future delivery date from DCAS. <a href="mailto:brandon.chiazza@mocs.nyc.gov?subject=NYCPPE%20Data%20Update%20Requested&body=Please%20update%20the%20DCAS%20ordering%20charts%20data%20at%20your%20earliest%20convenience.">[Request update]</a></dd>
-    <dt>Make</dt>
-    <dd>Purchase orders for manufacturing, from EDC. <a href="mailto:tchilds@edc.nyc?subject=NYCPPE%20Data%20Update%20Requested&body=Please%20update%20the%20EDC%20PPE%20data%20at%20your%20earliest%20convenience.">[Request update]</a></dd>
-    <dt>Donate</dt>
-    <dd>Pledged donations that have not yet been received, from DCAS. <a href="mailto:awichowski@cto.nyc.gov?subject=NYCPPE%20Data%20Update%20Requested&body=Please%20update%20the%20EDC%20PPE%20data%20at%20your%20earliest%20convenience.">[Request update]</a></dd>
-</dl>
-
-{% endblock %}


### PR DESCRIPTION
Using "pending pledges" language and Alexis as the contact.

Also adds the definition list to all pages by default

<img width="1315" alt="Screen Shot 2020-04-17 at 11 53 00 AM" src="https://user-images.githubusercontent.com/69848/79588489-ffec7d00-80a1-11ea-8302-ef2a1a783a0d.png">
