### PR TITLE
Use freeze gun to fix the build

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -19,6 +19,7 @@ whitenoise = "*"
 ortools = "*"
 black = "*"
 sentry-sdk = "*"
+freezegun = "*"
 
 [requires]
 python_version = "3.8"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "29541b579e2df5a4a6572a1cc3fafae0d9e15ebdf0bcc55675e290db6569ea32"
+            "sha256": "d70e6373f97041fe3570ca0225220e115f0f49d6cda0558467455e961456b2cd"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -22,6 +22,14 @@
                 "sha256:d8b24664561d0d34ddfaec54636d502d7cea6e29c3eaf68f3df6180863e2166e"
             ],
             "version": "==1.4.3"
+        },
+        "appnope": {
+            "hashes": [
+                "sha256:5b26757dc6f79a3b7dc9fab95359328d5747fcb2409d331ea66d0272b90ab2a0",
+                "sha256:8b995ffe925347a2138d7ac0fe77155e4311a0ea6d6da4f5128fe4b3cbe5ed71"
+            ],
+            "markers": "sys_platform == 'darwin'",
+            "version": "==0.1.0"
         },
         "asgiref": {
             "hashes": [
@@ -118,6 +126,14 @@
                 "sha256:614d9722d572f6246302c4491846d2c393c199cfa4edc9af593437691683335b"
             ],
             "version": "==1.0.1"
+        },
+        "freezegun": {
+            "hashes": [
+                "sha256:82c757a05b7c7ca3e176bfebd7d6779fd9139c7cb4ef969c38a28d74deef89b2",
+                "sha256:e2062f2c7f95cc276a834c22f1a17179467176b624cc6f936e8bc3be5535ad1b"
+            ],
+            "index": "pypi",
+            "version": "==0.3.15"
         },
         "gunicorn": {
             "hashes": [
@@ -293,6 +309,13 @@
                 "sha256:ff7a40b4860b727ab48fad6360eb351cc1b33cbf9b15a0f689ca5353e9463324"
             ],
             "version": "==2.6.1"
+        },
+        "python-dateutil": {
+            "hashes": [
+                "sha256:73ebfe9dbf22e832286dafa60473e4cd239f8592f699aa5adaf10050e6e1823c",
+                "sha256:75bb3f31ea686f1197762692a9ee6a7550b59fc6ca3a1f4b5d7e32fb98e2da2a"
+            ],
+            "version": "==2.8.1"
         },
         "pytz": {
             "hashes": [

--- a/nyc_data/ppe/tests.py
+++ b/nyc_data/ppe/tests.py
@@ -3,6 +3,7 @@ from datetime import datetime, timedelta
 
 from django.test import TestCase, override_settings
 from django.urls import reverse
+from freezegun import freeze_time
 
 from ppe import aggregations
 from ppe.aggregations import AssetRollup, DemandSrc
@@ -97,6 +98,7 @@ class TestAssetRollup(TestCase):
             item.source = self.data_import
             item.save()
 
+    @freeze_time("2020-04-12")
     def test_rollup(self):
         today = datetime(2020, 4, 12)
         rollup = aggregations.asset_rollup_legacy(today - timedelta(days=27), today)


### PR DESCRIPTION
Since we always consider the previous 7 calendar days (regardless of the search interval) for the delivery based demand calculation, use freeze_time to alwys run the tests as if it was 4/12