### PR TITLE
Fix error styling

### DIFF
--- a/nyc_data/ppe/static/style.css
+++ b/nyc_data/ppe/static/style.css
@@ -127,11 +127,6 @@ section.content {
     color: #CE4C23;
 }
 
-.error {
-    text-align: center;
-    display: block   
-}
-
 .balance-bar-red {
     background: #CE4C23;
 }
@@ -156,6 +151,11 @@ section.content {
 .lockdown, .upload { 
     display: flex;
     justify-content: center;
+}
+
+.upload .error {
+    text-align: center;
+    display: block   
 }
 
 .lockdown form, .upload form {

--- a/nyc_data/ppe/templates/upload.html
+++ b/nyc_data/ppe/templates/upload.html
@@ -5,11 +5,6 @@
 {% endblock %}
 
 {% block content %}
-
-{% if error != None %}
-<h3 class="error red">Error! {{ error }}</h3>
-{% endif %}
-
 <div class="upload">
     {% if import_in_progress %}
     <form enctype="multipart/form-data" method="post" action="/cancel/{{ import_in_progress }}/">
@@ -20,6 +15,9 @@
     {% endif %}
     <form enctype="multipart/form-data" method="post" action="/upload/">
         {% csrf_token %}
+        {% if error != None %}
+            <h3 class="error red">Error! {{ error }}</h3>
+        {% endif %}
         {{ form }}
         <button class="standard-button" type="submit">Submit</button>
     </form>


### PR DESCRIPTION
The `error` class was styled for a particular use, but was used elsewhere for other purposes.

This makes the applied rules more specific to avoid these conflicts.