### PR TITLE
Support url params for `supply` column

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -21,6 +21,7 @@ black = "*"
 sentry-sdk = "*"
 django-allauth = "*"
 freezegun = "*"
+werkzeug = "*"
 
 [requires]
 python_version = "3.8"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "b1dc38c847a66660c38db1bb380e05f4ff299062b0e97afbe50aecd92e07c4cb"
+            "sha256": "1fc522d19593edd4a6380fc24a59e1650feb03f1498692f519624b29e6d9086c"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -473,6 +473,14 @@
                 "sha256:ee73862862a156bf77ff92b09034fc4825dd3af9cf81bc5b360668d425f3c5f1"
             ],
             "version": "==0.1.9"
+        },
+        "werkzeug": {
+            "hashes": [
+                "sha256:2de2a5db0baeae7b2d2664949077c2ac63fbd16d98da0ff71837f7d1dea3fd43",
+                "sha256:6c80b1e5ad3665290ea39320b91e1be1e0d5f60652b964a3070216de83d2e47c"
+            ],
+            "index": "pypi",
+            "version": "==1.0.1"
         },
         "whitenoise": {
             "hashes": [

--- a/nyc_data/ppe/aggregations.py
+++ b/nyc_data/ppe/aggregations.py
@@ -389,7 +389,11 @@ class AggregationTable(tables.Table):
             "th": {
                 "class": "tooltip",
                 "aria-label": lambda: f"DOHMH [{Inventory.as_of_latest()}]",
-            }
+                "data-supply-col": lambda bound_column: bound_column.name,
+            },
+            "td": {
+                "data-supply-col": lambda bound_column: bound_column.name,
+            },
         }
     )
     donated = NumericalColumn(
@@ -398,7 +402,11 @@ class AggregationTable(tables.Table):
             "th": {
                 "class": "tooltip",
                 "aria-label": lambda: f"DCAS pending pledges [{current_as_of(Purchase.active().filter(order_type=dc.OrderType.Donation))}]",
+                "data-supply-col": lambda bound_column: bound_column.name,
             },
+            "td": {
+                "data-supply-col": lambda bound_column: bound_column.name,
+            }
         },
     )
     ordered = NumericalColumn(
@@ -407,6 +415,10 @@ class AggregationTable(tables.Table):
             "th": {
                 "class": "tooltip",
                 "aria-label": lambda: f"DCAS scheduled orders [{current_as_of(Purchase.active().filter(order_type=dc.OrderType.Purchase))}]",
+                "data-supply-col": lambda bound_column: bound_column.name,
+            },
+            "td": {
+                "data-supply-col": lambda bound_column: bound_column.name,
             },
         },
     )
@@ -417,7 +429,11 @@ class AggregationTable(tables.Table):
             "th": {
                 "class": "tooltip",
                 "aria-label": lambda: f"EDC scheduled deliveries [{current_as_of(Purchase.active().filter(order_type=dc.OrderType.Make))}]",
-            }
+                "data-supply-col": lambda bound_column: bound_column.name,
+            },
+            "td": {
+                "data-supply-col": lambda bound_column: bound_column.name,
+            },
         },
     )
 

--- a/nyc_data/ppe/aggregations.py
+++ b/nyc_data/ppe/aggregations.py
@@ -36,7 +36,7 @@ DEMAND_MESSAGE = (
 
 
 class AggColumn(str, Enum):
-    Donation = "donation"
+    Donation = "donated"
     Made = "made"
     Ordered = "ordered"
     Inventory = "inventory"
@@ -379,7 +379,7 @@ class AggregationTable(tables.Table):
         verbose_name="Supply",
         attrs={
             "th": {
-                "class": "tooltip",
+                "class": "tooltip supply-col",
                 "aria-label": "Sum of inventory, ordered, and made.",
             }
         },

--- a/nyc_data/ppe/aggregations.py
+++ b/nyc_data/ppe/aggregations.py
@@ -13,14 +13,12 @@ from django.utils.http import urlencode
 from django.utils.safestring import mark_safe
 
 import ppe.dataclasses as dc
-from ppe.data_mapping.types import DataFile
 from ppe.dataclasses import Period, OrderType
 from ppe.models import (
     ScheduledDelivery,
     Inventory,
     FacilityDelivery,
     Demand,
-    DataImport,
     Purchase,
     current_as_of,
 )
@@ -35,6 +33,17 @@ ALL_BEDS_AVAILABLE = 20420
 DEMAND_MESSAGE = (
     "Demand projected based on multiple sources and hospitalization models."
 )
+
+
+class AggColumn(str, Enum):
+    Donation = "donation"
+    Made = "made"
+    Ordered = "ordered"
+    Inventory = "inventory"
+
+    @classmethod
+    def all(cls):
+        return {cls.Donation, cls.Made, cls.Ordered, cls.Inventory}
 
 
 class DemandCalculationConfig(NamedTuple):
@@ -57,16 +66,29 @@ class DemandSrc(str, Enum):
 @dataclass
 class AssetRollup:
     asset: str
+    total_cols: Set["AggColumn"]
     demand: int = 0
     demand_src: Set[DemandSrc] = field(default_factory=set)
-    donate: int = 0
-    sell: int = 0
-    make: int = 0
+    donated: int = 0
+    ordered: int = 0
+    made: int = 0
     inventory: int = 0
+
+    def _value_at(self, agg_column: AggColumn):
+        if agg_column == AggColumn.Made:
+            return self.made
+        elif agg_column == AggColumn.Ordered:
+            return self.ordered
+        elif agg_column == AggColumn.Inventory:
+            return self.inventory
+        elif agg_column == AggColumn.Donation:
+            return self.donated
+        else:
+            raise Exception("Invalid agg column")
 
     @property
     def total(self):
-        return self.donate + self.sell + self.make + self.inventory
+        return sum(self._value_at(col) for col in self.total_cols)
 
     @property
     def absolute_balance(self):
@@ -79,11 +101,12 @@ class AssetRollup:
     def __add__(self, other: "AssetRollup"):
         return AssetRollup(
             asset=self.asset,
+            total_cols=self.total_cols,
             demand=self.demand + other.demand,
             demand_src=self.demand_src.union(other.demand_src),
-            donate=self.donate + other.donate,
-            sell=self.sell + other.sell,
-            make=self.make + other.make,
+            donated=self.donated + other.donated,
+            ordered=self.ordered + other.ordered,
+            made=self.made + other.made,
             inventory=self.inventory + other.inventory,
         )
 
@@ -96,9 +119,9 @@ class AssetRollup:
 
 
 MAPPING = {
-    dc.OrderType.Make: "make",
-    dc.OrderType.Purchase: "sell",
-    dc.OrderType.Donation: "donate",
+    dc.OrderType.Make: "made",
+    dc.OrderType.Purchase: "ordered",
+    dc.OrderType.Donation: "donated",
 }
 
 
@@ -110,8 +133,9 @@ def asset_rollup_legacy(
     rollup_fn: Callable[[dc.Item], str] = lambda x: x,
 ):
     return asset_rollup(
-        Period(time_start, time_end),
-        DemandCalculationConfig(
+        time_range=Period(time_start, time_end),
+        supply_cols=AggColumn.all(),
+        demand_calculation_config=DemandCalculationConfig(
             use_real_demand,
             use_hospitalization_projection=use_hospitalization_projection,
             rollup_fn=rollup_fn,
@@ -121,7 +145,9 @@ def asset_rollup_legacy(
 
 @log_db_queries
 def asset_rollup(
-    time_range: Period, demand_calculation_config: DemandCalculationConfig,
+    time_range: Period,
+    supply_cols: Set[AggColumn],
+    demand_calculation_config: DemandCalculationConfig,
 ) -> Dict[str, AssetRollup]:
     time_start, time_end = time_range.start, time_range.end
     relevant_deliveries = (
@@ -140,7 +166,7 @@ def asset_rollup(
 
     results: Dict[dc.Item, AssetRollup] = {}
     for _, item in dc.Item.__members__.items():
-        results[item] = AssetRollup(asset=item)
+        results[item] = AssetRollup(asset=item, total_cols=supply_cols)
 
     for delivery in relevant_deliveries:
         rollup = results[delivery.purchase.item]
@@ -174,7 +200,9 @@ def asset_rollup(
     for item, rollup in results.items():
         rolledup_category = demand_calculation_config.rollup_fn(item)
         if not rolledup_category in rollup_results:
-            rollup_results[rolledup_category] = AssetRollup(asset=rolledup_category)
+            rollup_results[rolledup_category] = AssetRollup(
+                asset=rolledup_category, total_cols=supply_cols
+            )
         rollup_results[rolledup_category] += rollup
 
     return rollup_results
@@ -364,7 +392,7 @@ class AggregationTable(tables.Table):
             }
         }
     )
-    donate = NumericalColumn(
+    donated = NumericalColumn(
         verbose_name="Donated",
         attrs={
             "th": {
@@ -373,7 +401,7 @@ class AggregationTable(tables.Table):
             },
         },
     )
-    sell = NumericalColumn(
+    ordered = NumericalColumn(
         verbose_name="Ordered",
         attrs={
             "th": {
@@ -383,7 +411,7 @@ class AggregationTable(tables.Table):
         },
     )
 
-    make = NumericalColumn(
+    made = NumericalColumn(
         verbose_name="Made",
         attrs={
             "th": {
@@ -462,16 +490,6 @@ class AggregationTable(tables.Table):
             pos_delta=50 - max(min(int(percent * 50), 50), 0),
         )
 
-        # """
-        # <span>
-        #    <span class="value balance-col {color_class}">{value}</span><span class="unit">{unit}</span>
-        #    <span>&nbsp;<span class="value-divider">/</span>&nbsp;</span>
-        #    <span>
-        #        <span class="value {color_class} balance-col">{percent}</span><span class="unit">%</span>
-        #    </span>
-        # </span>
-        # """
-
     class Meta:
         order_by = ("balance",)
         sequence = (
@@ -480,9 +498,9 @@ class AggregationTable(tables.Table):
             "total",
             "balance",
             "inventory",
-            "sell",
-            "make",
-            "donate",
+            "ordered",
+            "made",
+            "donated",
         )
 
 

--- a/nyc_data/ppe/static/script.js
+++ b/nyc_data/ppe/static/script.js
@@ -92,19 +92,51 @@ $(function(){
     if($('.dashboard-table').length > 0){
         var enabledSupply = searchParams.get('supply') ? searchParams.get('supply').split(',') : [];
         var allSupply = [];
+        var disabledSupply = [];
+
+        $('.supply-col').find('a').after(svgGear);
+        $('th[data-supply-col]').each(function(){
+            allSupply.push($(this).attr('data-supply-col'));
+        });
+
+        disabledSupply = [...allSupply].filter(x => !enabledSupply.includes(x));
+
         if (enabledSupply.length) {
-            $('th[data-supply-col]').each(function(){
-                allSupply.push($(this).attr('data-supply-col'));
-            });
+            if (disabledSupply.length) {
+                // Mute disabled columns
+                for (var disabledColumn of disabledSupply) {
+                    $(`[data-supply-col=${disabledColumn}]`).addClass('disabled');
+                }
+                $('.supply-col').addClass('active');
+            }
 
-            disabledSupply = [...allSupply].filter(x => !enabledSupply.includes(x));
-
-            // Mute disabled columns
-            for (var disabledColumn of disabledSupply) {
-                $(`[data-supply-col=${disabledColumn}]`).addClass('disabled');
+            if(enabledSupply.length && enabledSupply.length != allSupply.length) {
+                $('.supply-col svg').addClass('active');
             }
         }
+
+        $('.supply-col svg').after(`<div class="supply-controls"><h3>Include in supply:</h3><ul></ul></div>`);
+        for (col of allSupply) {
+            if (!enabledSupply.length || enabledSupply.includes(col)) {
+                $('.supply-controls ul').append(`<li><input type="checkbox" checked="checked" value="${col}" />${col}</li>`);
+            } else {
+                $('.supply-controls ul').append(`<li><input type="checkbox" value="${col}" />${col}</li>`);
+            }
+        }
+        $('.supply-controls ul').append('<button>Change</button>')
+
+        $('.supply-col svg').click(function(){ $('.supply-controls').toggle(); });
+        $('.supply-controls button').click(function(){
+            var newSupply = [];
+            $('.supply-controls li input').each(function(){
+                if ($(this).is(':checked')) {
+                    newSupply.push($(this).attr('value'));
+                }
+            });
+            addUrlParameter('supply', newSupply.join(','));
+        });
     }
 });
 
-svgClock = '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512"><path d="M256 8a248 248 0 100 496 248 248 0 000-496zm0 448a200 200 0 110-400 200 200 0 010 400zm62-104l-85-62c-3-2-5-6-5-10V116c0-7 5-12 12-12h32c7 0 12 5 12 12v142l67 48c5 4 6 12 2 17l-18 26c-4 5-12 7-17 3z"/></svg>'
+svgClock = '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512"><path d="M256 8a248 248 0 100 496 248 248 0 000-496zm0 448a200 200 0 110-400 200 200 0 010 400zm62-104l-85-62c-3-2-5-6-5-10V116c0-7 5-12 12-12h32c7 0 12 5 12 12v142l67 48c5 4 6 12 2 17l-18 26c-4 5-12 7-17 3z"/></svg>';
+svgGear = '<svg class="settings" viewBox="0 0 72 72" xmlns="http://www.w3.org/2000/svg"><path d="M71.754 28.773h-8.21c-4.381 0-5.431-2.535-2.334-5.631l5.807-5.806a.25.25 0 000-.349l-5.539-5.539a7059.707 7059.707 0 01-5.539-5.538.248.248 0 00-.348 0c-.096.097-2.707 2.709-5.805 5.806s-5.631 2.048-5.631-2.332v-8.21a.246.246 0 00-.246-.246H28.243a.246.246 0 00-.246.246v8.21c0 4.38-2.533 5.429-5.631 2.332L16.56 5.91a.248.248 0 00-.348 0c-.095.097-2.588 2.589-5.538 5.538l-5.539 5.539a.247.247 0 000 .349l5.805 5.806c3.098 3.096 2.048 5.631-2.332 5.631H.397a.247.247 0 00-.246.247v15.665c0 .135.111.246.246.246h8.209c4.381 0 5.43 2.534 2.334 5.631l-5.805 5.804a.247.247 0 000 .349l5.538 5.539 5.539 5.539a.246.246 0 00.348 0c.095-.097 2.709-2.709 5.805-5.806 3.099-3.097 5.632-2.047 5.632 2.332v8.211c0 .136.111.246.246.246h15.666c.135 0 .246-.11.246-.246v-8.211c0-4.379 2.533-5.429 5.631-2.333l5.806 5.806a.246.246 0 00.348 0c.095-.097 2.588-2.589 5.538-5.539l5.539-5.538a.25.25 0 000-.349l-5.805-5.804c-3.097-3.097-2.047-5.631 2.333-5.631h8.209a.246.246 0 00.246-.246v-7.833-7.832a.247.247 0 00-.246-.247zm-35.14 19.893c-6.663 0-12.064-5.4-12.064-12.063s5.401-12.065 12.064-12.065c6.662 0 12.065 5.402 12.065 12.065 0 6.663-5.403 12.063-12.065 12.063z" fill="#000" fill-rule="evenodd"/></svg>';

--- a/nyc_data/ppe/static/script.js
+++ b/nyc_data/ppe/static/script.js
@@ -77,7 +77,6 @@ $(function(){
                 daystring = matches[1].replace(/-/g,'');
                 day = moment(daystring);
                 days = moment().diff(day, 'days');
-                console.log($(this), days);
                 if (days > 3) {
                     $(this).addClass('error');
                     $(this).find('a').after(svgClock);
@@ -87,6 +86,24 @@ $(function(){
                 } 
             } 
         });
+    }
+
+    // Supply data column configuration
+    if($('.dashboard-table').length > 0){
+        var enabledSupply = searchParams.get('supply') ? searchParams.get('supply').split(',') : [];
+        var allSupply = [];
+        if (enabledSupply.length) {
+            $('th[data-supply-col]').each(function(){
+                allSupply.push($(this).attr('data-supply-col'));
+            });
+
+            disabledSupply = [...allSupply].filter(x => !enabledSupply.includes(x));
+
+            // Mute disabled columns
+            for (var disabledColumn of disabledSupply) {
+                $(`[data-supply-col=${disabledColumn}]`).addClass('disabled');
+            }
+        }
     }
 });
 

--- a/nyc_data/ppe/static/style.css
+++ b/nyc_data/ppe/static/style.css
@@ -543,3 +543,59 @@ body.drilldown .dashboard-table {
     border: 1px solid #ddd;
     color: #fff;
 }
+
+/* Supply controls */
+
+.supply-col svg {
+    height: 14px;
+    width: 14px;
+    cursor: pointer;
+}
+
+.supply-col svg path { fill: #888; }
+.supply-col svg.active path { fill: #8c8; }
+
+.supply-controls {
+    display: none;
+    position: absolute;
+    background: #fff;
+    box-shadow: 0px 0px 20px #0003;
+    border-radius: 5px;
+    min-width: 200px;
+    margin-top: 10px;
+}
+
+.supply-controls h3 {
+    padding: 5px 10px;
+    font-size: 14px;
+    font-weight: 333;
+    margin: 0 0 10px 0;
+    background: #333;
+    color: #fff;
+    border-top-left-radius: 5px;
+    border-top-right-radius: 5px;
+}
+
+.supply-controls ul {
+    list-style-type: none;
+    margin: 5px 10px;
+    padding: 0;
+}
+
+.supply-controls li {
+    font-weight: 300;
+    font-size: 14px;
+    padding-bottom: 5px;
+}
+
+.supply-controls button {
+    background: #888;
+    color: #fff;
+    border-radius: 20px;
+    padding: 5px 10px;
+    margin: 10px 0;
+}
+
+.supply-controls input {
+    margin-right: 10px;
+}

--- a/nyc_data/ppe/static/style.css
+++ b/nyc_data/ppe/static/style.css
@@ -397,6 +397,10 @@ body.drilldown .dashboard-table {
     text-align: left;
 }
 
+.dashboard-table td.disabled .value, .dashboard-table td.disabled .unit, .dashboard-table th.disabled a, .dashboard-table td.disabled {
+    color: #ccc;
+}
+
 .dashboard-table td {
     white-space: pre;
 }

--- a/nyc_data/ppe/tests.py
+++ b/nyc_data/ppe/tests.py
@@ -2,18 +2,18 @@ import unittest
 from datetime import datetime, timedelta
 
 from django.contrib import auth
-from django.test import TestCase, override_settings
+from django.test import TestCase
 from django.urls import reverse
 from freezegun import freeze_time
 
+import ppe.dataclasses as dc
 from ppe import aggregations
-from ppe.aggregations import AssetRollup, DemandSrc
-from ppe.dataclasses import Period
-from ppe.data_mapping.types import DataFile
+from ppe.aggregations import AssetRollup, DemandSrc, AggColumn
 from ppe.data_mapping.mappers.dcas_sourcing import SourcingRow
 from ppe.data_mapping.mappers.hospital_demands import DemandRow
-import ppe.dataclasses as dc
+from ppe.data_mapping.types import DataFile
 from ppe.data_mapping.utils import ErrorCollector
+from ppe.dataclasses import Period
 from ppe.models import (
     DataImport,
     ImportStatus,
@@ -109,10 +109,11 @@ class TestAssetRollup(TestCase):
             rollup[dc.Item.gown],
             AssetRollup(
                 asset=dc.Item.gown,
+                total_cols=AggColumn.all(),
                 inventory=100,
                 demand_src={DemandSrc.real_demand},
                 demand=7654622,
-                sell=5,
+                ordered=5,
             ),
         )
 
@@ -124,10 +125,11 @@ class TestAssetRollup(TestCase):
             rollup[dc.Item.gown],
             AssetRollup(
                 asset=dc.Item.gown,
+                total_cols=AggColumn.all(),
                 inventory=100,
                 demand_src={DemandSrc.real_demand},
                 demand=2457000 * 4,
-                sell=5,
+                ordered=5,
             ),
         )
 
@@ -136,10 +138,11 @@ class TestAssetRollup(TestCase):
             rollup[dc.Item.faceshield],
             AssetRollup(
                 asset=dc.Item.faceshield,
+                total_cols=AggColumn.all(),
                 inventory=0,
                 demand_src={DemandSrc.past_deliveries},
                 demand=123 * 4,
-                sell=0,
+                ordered=0,
             ),
         )
 
@@ -156,8 +159,9 @@ class TestAssetRollup(TestCase):
             future_rollup[dc.Item.gown],
             AssetRollup(
                 asset=dc.Item.gown,
+                total_cols=AggColumn.all(),
                 demand=1234 * 4,
-                sell=1000,
+                ordered=1000,
                 demand_src={DemandSrc.past_deliveries},
                 inventory=100,
             ),
@@ -184,7 +188,10 @@ class TestAssetRollup(TestCase):
             self.assertEqual(aggregations.known_recent_demand(), {})
             rollup = aggregations.asset_rollup_legacy(today - timedelta(days=28), today)
             self.assertEqual(
-                rollup[dc.Item.gown], AssetRollup(asset=dc.Item.gown, demand=0, sell=0)
+                rollup[dc.Item.gown],
+                AssetRollup(
+                    asset=dc.Item.gown, total_cols=AggColumn.all(), demand=0, ordered=0
+                ),
             )
         finally:
             self.data_import.status = ImportStatus.active
@@ -278,3 +285,18 @@ class TestPeriod(unittest.TestCase):
             Period(start, start + timedelta(days=6)).inclusive_length(),
             timedelta(days=7),
         )
+
+
+class TestRollupObj(unittest.TestCase):
+    def test_rollup_obj(self):
+        rollup = AssetRollup(
+            asset=dc.Item.gown,
+            total_cols={AggColumn.Ordered, AggColumn.Made},
+            donated=100,
+            made=456,
+            ordered=789,
+            demand=0,
+            demand_src=set(),
+        )
+
+        self.assertEqual(rollup.total, 789 + 456)

--- a/nyc_data/ppe/views.py
+++ b/nyc_data/ppe/views.py
@@ -1,5 +1,5 @@
 from datetime import datetime, timedelta, date
-from typing import NamedTuple, Optional, Callable
+from typing import NamedTuple, Optional, Callable, Set
 
 from django.contrib.auth.decorators import login_required
 from django.contrib.auth.mixins import LoginRequiredMixin
@@ -14,7 +14,7 @@ from django_tables2 import RequestConfig
 import ppe.errors
 from ppe import aggregations, dataclasses as dc
 from ppe import forms, data_import
-from ppe.aggregations import DemandCalculationConfig
+from ppe.aggregations import DemandCalculationConfig, AggColumn
 from ppe.data_mapping.utils import parse_date, ErrorCollector
 from ppe.drilldown import drilldown_result
 from ppe.models import DataImport
@@ -29,6 +29,7 @@ class StandardRequestParams(NamedTuple):
     start_date: date  # usually today
     end_date: date  # usually today + n days
     rollup_fn: Callable[[str], str]
+    supply_components: Set[AggColumn]
 
     def time_range(self):
         return dc.Period(self.start_date, self.end_date)
@@ -54,11 +55,21 @@ class StandardRequestParams(NamedTuple):
         else:
             rollup_fn = lambda x: x
 
+        if params.get("supply"):
+            supply_components = {
+                AggColumn(col) for col in params.get("supply").split(",")
+            }
+        else:
+            supply_components = AggColumn.all()
+
         print(f"Parsed request as {start_date}->{end_date}")
         if len(err_collector) > 0:
             err_collector.dump()
         return StandardRequestParams(
-            start_date=start_date, end_date=end_date, rollup_fn=rollup_fn
+            start_date=start_date,
+            end_date=end_date,
+            rollup_fn=rollup_fn,
+            supply_components=supply_components,
         )
 
 
@@ -68,14 +79,14 @@ def default(request):
 
     aggregation = aggregations.asset_rollup(
         time_range=params.time_range(),
+        supply_cols=params.supply_components,
         demand_calculation_config=DemandCalculationConfig(rollup_fn=params.rollup_fn),
     )
 
-    displayed_vals = ["donate", "sell", "make", "inventory"]
     cleaned_aggregation = [
         rollup
         for rollup in list(aggregation.values())
-        if not all([getattr(rollup, val) == 0 for val in displayed_vals])
+        if not all([rollup._value_at(col) == 0 for col in AggColumn.all()])
     ]
 
     table = aggregations.AggregationTable(cleaned_aggregation)
@@ -97,7 +108,10 @@ def drilldown(request):
         return HttpResponse("Need an asset category param", status=400)
 
     drilldown_res = drilldown_result(
-        category, params.rollup_fn, time_range=params.time_range()
+        category,
+        params.rollup_fn,
+        time_range=params.time_range(),
+        supply_cols=params.supply_components,
     )
     table = aggregations.TotaledAggregationTable(drilldown_res.aggregation.values())
     RequestConfig(request).configure(table)


### PR DESCRIPTION
`?supply=ordered,donated`

It defaults to all columns if no parameter is specified. I also refactored so that the code has the same names as the UI for the different columns. It should work on both the dashboard & drill down pages.

Valid params come from:
```python
class AggColumn(str, Enum):
    Donation = "donation"
    Made = "made"
    Ordered = "ordered"
    Inventory = "inventory"
```