### PR TITLE
Security reviews

### DIFF
--- a/nyc_data/nyc_data/auth.py
+++ b/nyc_data/nyc_data/auth.py
@@ -1,6 +1,26 @@
+import re
+
+from django.core.exceptions import ValidationError
 from allauth.account.adapter import DefaultAccountAdapter
 
 
 class ClosedAccountAdapter(DefaultAccountAdapter):
     def is_open_for_signup(self, request):
         return False
+
+
+class CharacterComplexityValidator:
+    PATTERN = r'^(?=.*[A-Za-z].*)(?=.*[0-9{}\[\],.<>;:\'\"?\/|\\`~!@#$^&*()_\-+=].*).*$'
+
+    def __init__(self, min_length=8):
+        self.min_length = min_length
+
+    def validate(self, password, user=None):
+        if re.search(self.PATTERN, password) is None:
+            raise ValidationError(
+                "This password must contain at least one letter and one number or special character.",
+                code="password_needs_special_characters",
+            )
+
+    def get_help_text(self):
+        return "Your password must contain at least one letter and one number or special character ({}\[\],.<>;:'\"?/|\`~!@#$^&*()_\-+=)"

--- a/nyc_data/nyc_data/settings/common.py
+++ b/nyc_data/nyc_data/settings/common.py
@@ -126,7 +126,20 @@ STATIC_ROOT = os.path.join(BASE_DIR, "static")
 
 # Authentication config
 
-AUTH_PASSWORD_VALIDATORS = []  # No password constraints
+PASSWORD_HASHERS = [  # NYC Standard 4
+    'django.contrib.auth.hashers.PBKDF2PasswordHasher',
+    'django.contrib.auth.hashers.PBKDF2SHA1PasswordHasher',
+    'django.contrib.auth.hashers.Argon2PasswordHasher',
+    'django.contrib.auth.hashers.BCryptSHA256PasswordHasher',
+]
+
+AUTH_PASSWORD_VALIDATORS = [
+    {"NAME": "django.contrib.auth.password_validation.UserAttributeSimilarityValidator",},  # NYC Standard 11
+    {"NAME": "django.contrib.auth.password_validation.MinimumLengthValidator", "OPTIONS": {'min_length': 8,}},  # NYC Standard 9
+    {"NAME": "django.contrib.auth.password_validation.CommonPasswordValidator",},  # NYC Standard 11
+    {"NAME": "django.contrib.auth.password_validation.NumericPasswordValidator",},  # NYC Standard 8
+    {"NAME": "nyc_data.auth.CharacterComplexityValidator",}, # NYC Standard 10
+]
 
 AUTHENTICATION_BACKENDS = [
     "django.contrib.auth.backends.ModelBackend",
@@ -139,10 +152,10 @@ ACCOUNT_ADAPTER = "nyc_data.auth.ClosedAccountAdapter"  # Don't allow signups
 ACCOUNT_SESSION_REMEMBER = True  # Allow users to stay logged in
 ACCOUNT_EMAIL_VERIFICATION = "none"  # Don't require email verification
 ACCOUNT_AUTHENTICATION_METHOD = "username_email"  # log in with either username or email
-ACCOUNT_DEFAULT_HTTP_PROTOCOL = "https"  # links should use HTTPS
-ACCOUNT_LOGIN_ATTEMPTS_LIMIT = 5  # Timeout after this many failed attempts
+ACCOUNT_DEFAULT_HTTP_PROTOCOL = "https"  # links should use HTTPS - NYC Standard 4
+ACCOUNT_LOGIN_ATTEMPTS_LIMIT = 5  # Timeout after this many failed attempts - NYC Standard 7
 ACCOUNT_LOGIN_ATTEMPTS_TIMEOUT = (
-    300  # Duration of timeout after failed attempts in seconds
+    900  # Duration of timeout after failed attempts in seconds - NYC Standard 7
 )
 
 

--- a/nyc_data/templates/account/login.html
+++ b/nyc_data/templates/account/login.html
@@ -13,8 +13,6 @@
     <input type="hidden" name="{{ redirect_field_name }}" value="{{ redirect_field_value }}" />
     {% endif %}
     <button class="primaryAction" type="submit">Sign In</button>
-    <p><a class="button secondaryAction" href="{% url 'account_reset_password' %}">Forgot Password?</a></p>
-
     </form>
 </div>
 {% endblock %}


### PR DESCRIPTION
Some stuff to prep for the NYC security review. Includes:

* Disabling password resets completely (the link was left there errantly)
* Enforcing password requirements per https://www1.nyc.gov/assets/doitt/downloads/pdf/password.pdf