### PR TITLE
Add deprecation note  for notifying visitors

### DIFF
--- a/nyc_data/ppe/templates/base.html
+++ b/nyc_data/ppe/templates/base.html
@@ -13,7 +13,7 @@
         <strong>CONFIDENTIAL.</strong>&nbsp;DO NOT DISTRIBUTE WITHOUT AUTHORIZATION.
     </section>
     <section style='background: darkred; color: white; text-align: center; padding: 10px;'>
-        <strong>⚠️ The PPE Dashboard will be deprecated on October 31, 2020. Please contact the <a href="mailto:jiman@cto.nyc.gov" style="color: white; text-decoration: underline;">CTO's office</a> for more information. ⚠️</strong>
+        <strong>⚠️ The PPE Dashboard will be shut down on October 31, 2020. Please contact the <a href="mailto:digital@cto.nyc.gov" style="color: white; text-decoration: underline;">digital@cto.nyc.gov</a> for more information. ⚠️</strong>
     </section>
 
     <section class="brand-bar container">

--- a/nyc_data/ppe/templates/base.html
+++ b/nyc_data/ppe/templates/base.html
@@ -12,6 +12,10 @@
     <section class="disclaimer">
         <strong>CONFIDENTIAL.</strong>&nbsp;DO NOT DISTRIBUTE WITHOUT AUTHORIZATION.
     </section>
+    <section style='background: darkred; color: white; text-align: center; padding: 10px;'>
+        <strong>⚠️ The PPE Dashboard will be deprecated on October 31, 2020. Please contact the <a href="mailto:jiman@cto.nyc.gov" style="color: white; text-decoration: underline;">CTO's office</a> for more information. ⚠️</strong>
+    </section>
+
     <section class="brand-bar container">
         <div>
         <a href="/">NYC<b>PPE</b></a>


### PR DESCRIPTION
Hi folks, Rapi here from the CTO's office. NYC PPE Dashboard's starting the process of deprecating this and we're hoping to deprecate it by October 31. Would it be possible to add this to the code as well as the Heroku instance? I understand it's currently running in Heroku? Would love to chat and touch base! Thanks!